### PR TITLE
Connect-Salesforce-with-slack-Permission-Set

### DIFF
--- a/unpackaged/main/default/permissionsets/Connect_Salesforce_with_Slack.permissionset-meta.xml
+++ b/unpackaged/main/default/permissionsets/Connect_Salesforce_with_Slack.permissionset-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Connect Salesforce with Slack</label>
+</PermissionSet>


### PR DESCRIPTION
Permission set allowing CRM Analytics users to connect to Slack