### PR TITLE
Product-picker-adds-multiple-lines-in-error

### DIFF
--- a/unpackaged/main/default/flows/Opportunity_Product_Selection_Screen_Flow.flow-meta.xml
+++ b/unpackaged/main/default/flows/Opportunity_Product_Selection_Screen_Flow.flow-meta.xml
@@ -3,7 +3,7 @@
     <actionCalls>
         <name>Open_Parent_Opportunity</name>
         <label>Open Parent Opportunity</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>23870</locationY>
         <actionName>c:fsc_openUrl</actionName>
         <actionType>component</actionType>
@@ -14,7 +14,9 @@
                 <elementReference>fxParentOpportunityLink</elementReference>
             </value>
         </inputParameters>
+        <nameSegment>c:fsc_openUrl</nameSegment>
         <storeOutputAutomatically>true</storeOutputAutomatically>
+        <versionSegment>1</versionSegment>
     </actionCalls>
     <apiVersion>56.0</apiVersion>
     <assignments>
@@ -36,8 +38,8 @@
     <assignments>
         <name>Add_Edited_Addon_Id_to_Collection</name>
         <label>Add Edited Addon Id to Collection</label>
-        <locationX>4714</locationX>
-        <locationY>9260</locationY>
+        <locationX>5594</locationX>
+        <locationY>9884</locationY>
         <assignmentItems>
             <assignToReference>collSelectedProductIds</assignToReference>
             <operator>Add</operator>
@@ -50,48 +52,9 @@
         </connector>
     </assignments>
     <assignments>
-        <name>Add_Edited_Addon_to_Collection</name>
-        <label>Add Edited Addon to Collection</label>
-        <locationX>4626</locationX>
-        <locationY>9044</locationY>
-        <assignmentItems>
-            <assignToReference>collSelectedProducts</assignToReference>
-            <operator>Add</operator>
-            <value>
-                <elementReference>dtAddOnsAndServices.outputEditedRows</elementReference>
-            </value>
-        </assignmentItems>
-        <connector>
-            <targetReference>Edited_Addons_Loop</targetReference>
-        </connector>
-    </assignments>
-    <assignments>
-        <name>Add_Edited_Main_Product_to_Selected_Products_Collection</name>
-        <label>Add Edited Main Product to Selected Products Collection</label>
-        <locationX>7134</locationX>
-        <locationY>10034</locationY>
-        <assignmentItems>
-            <assignToReference>collSelectedProducts</assignToReference>
-            <operator>Add</operator>
-            <value>
-                <elementReference>dtMainProducts.outputEditedRows</elementReference>
-            </value>
-        </assignmentItems>
-        <assignmentItems>
-            <assignToReference>collAggregateSelectedProducts</assignToReference>
-            <operator>Add</operator>
-            <value>
-                <elementReference>dtMainProducts.outputEditedRows</elementReference>
-            </value>
-        </assignmentItems>
-        <connector>
-            <targetReference>Edited_Main_Products_Loop</targetReference>
-        </connector>
-    </assignments>
-    <assignments>
         <name>Add_Grandfathered_Add_Ons_to_Display_Collection</name>
         <label>Add Grandfathered Add Ons to Display Collection</label>
-        <locationX>5411</locationX>
+        <locationX>5991</locationX>
         <locationY>7568</locationY>
         <assignmentItems>
             <assignToReference>collDisplayProducts</assignToReference>
@@ -108,7 +71,7 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Sort_Display_Products_Collection</targetReference>
+            <targetReference>Update_Add_On_Quantity_Loop</targetReference>
         </connector>
     </assignments>
     <assignments>
@@ -130,8 +93,8 @@
     <assignments>
         <name>Add_Main_Product_to_Selected_Products_Collection2</name>
         <label>Add Main Product to Selected Products Collection</label>
-        <locationX>7134</locationX>
-        <locationY>10634</locationY>
+        <locationX>8358</locationX>
+        <locationY>10100</locationY>
         <assignmentItems>
             <assignToReference>collSelectedProducts</assignToReference>
             <operator>Add</operator>
@@ -181,7 +144,7 @@
     <assignments>
         <name>Add_Open_Open_Opportunity_Id_to_Collection</name>
         <label>Add Open Open Opportunity Id to Collection</label>
-        <locationX>7333</locationX>
+        <locationX>7913</locationX>
         <locationY>1172</locationY>
         <assignmentItems>
             <assignToReference>collOpenOpportunityIds</assignToReference>
@@ -197,7 +160,7 @@
     <assignments>
         <name>Add_Opportunity_SKU_Id_to_Collection</name>
         <label>Add Opportunity SKU Id to Collection</label>
-        <locationX>10341</locationX>
+        <locationX>11501</locationX>
         <locationY>5504</locationY>
         <assignmentItems>
             <assignToReference>collAllSkuProductIds</assignToReference>
@@ -243,7 +206,7 @@
     <assignments>
         <name>Add_Partnership_Discount_Promotion_to_Collection</name>
         <label>Add Partnership Discount Promotion to Collection</label>
-        <locationX>9765</locationX>
+        <locationX>10925</locationX>
         <locationY>8684</locationY>
         <assignmentItems>
             <assignToReference>collPromotionsOnPartnershipDiscount</assignToReference>
@@ -259,7 +222,7 @@
     <assignments>
         <name>Add_Product_Sku_Promotion_Id_to_Collection</name>
         <label>Add Product Sku Promotion Id to Collection</label>
-        <locationX>12320</locationX>
+        <locationX>13480</locationX>
         <locationY>6344</locationY>
         <assignmentItems>
             <assignToReference>collExcludeProductSkuPromotionIds</assignToReference>
@@ -275,7 +238,7 @@
     <assignments>
         <name>Add_Promotion_Id_to_Collection</name>
         <label>Add Promotion Id to Collection</label>
-        <locationX>10234</locationX>
+        <locationX>11394</locationX>
         <locationY>7052</locationY>
         <assignmentItems>
             <assignToReference>collShortTermPromotionIds</assignToReference>
@@ -291,8 +254,8 @@
     <assignments>
         <name>Add_Required_Products_to_Selected_Product_Collection</name>
         <label>Add Required Products to Selected Product Collection</label>
-        <locationX>7334</locationX>
-        <locationY>11774</locationY>
+        <locationX>8428</locationX>
+        <locationY>12566</locationY>
         <assignmentItems>
             <assignToReference>collSelectedProducts</assignToReference>
             <operator>Add</operator>
@@ -335,8 +298,8 @@
     <assignments>
         <name>Add_Selected_Add_Ons_and_Services_to_Selected_Products_Collection</name>
         <label>Add Selected Add Ons and Services to Selected Products Collection</label>
-        <locationX>4626</locationX>
-        <locationY>9644</locationY>
+        <locationX>5282</locationX>
+        <locationY>9176</locationY>
         <assignmentItems>
             <assignToReference>collSelectedProducts</assignToReference>
             <operator>Add</operator>
@@ -351,7 +314,7 @@
     <assignments>
         <name>Add_Selected_Lifetime_Promotion_to_Collection</name>
         <label>Add Selected Lifetime Promotion to Collection</label>
-        <locationX>11730</locationX>
+        <locationX>12890</locationX>
         <locationY>11660</locationY>
         <assignmentItems>
             <assignToReference>collSelectedPromotionSkus</assignToReference>
@@ -365,10 +328,33 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Add_Selected_Product_to_Collection</name>
+        <label>Add Selected Product to Collection</label>
+        <locationX>5638</locationX>
+        <locationY>10268</locationY>
+        <assignmentItems>
+            <assignToReference>collSelectedProducts</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>Selected_Addons_Loop</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>collSelectedProductIds</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>Selected_Addons_Loop.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Selected_Addons_Loop</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Add_Selected_Products_to_Aggregate_Collections</name>
         <label>Add Selected Products to Aggregate Collections</label>
-        <locationX>4758</locationX>
-        <locationY>10694</locationY>
+        <locationX>5240</locationX>
+        <locationY>11186</locationY>
         <assignmentItems>
             <assignToReference>collAggregateSelectedProductIds</assignToReference>
             <operator>Add</operator>
@@ -390,7 +376,7 @@
     <assignments>
         <name>Add_Selected_Promotion_SKUs_to_Collection</name>
         <label>Add Selected Promotion SKUs to Collection</label>
-        <locationX>11928</locationX>
+        <locationX>13088</locationX>
         <locationY>11960</locationY>
         <assignmentItems>
             <assignToReference>collSelectedPromotionSkus</assignToReference>
@@ -413,7 +399,7 @@
     <assignments>
         <name>Add_Selected_Promotion_SKUs_to_Collection3</name>
         <label>Add Selected Promotion SKUs to Collection</label>
-        <locationX>11400</locationX>
+        <locationX>12560</locationX>
         <locationY>12176</locationY>
         <assignmentItems>
             <assignToReference>collSelectedPromotionSkus</assignToReference>
@@ -429,7 +415,7 @@
     <assignments>
         <name>Add_SKU</name>
         <label>Add SKU</label>
-        <locationX>7441</locationX>
+        <locationX>8021</locationX>
         <locationY>2996</locationY>
         <assignmentItems>
             <assignToReference>coll_Picked_Sku_Product_Ids</assignToReference>
@@ -445,8 +431,8 @@
     <assignments>
         <name>Add_SKU_Product_Id_to_Collection</name>
         <label>Add SKU Product Id to Collection</label>
-        <locationX>7354</locationX>
-        <locationY>11042</locationY>
+        <locationX>8448</locationX>
+        <locationY>11834</locationY>
         <assignmentItems>
             <assignToReference>collRequiredProductIds</assignToReference>
             <operator>Add</operator>
@@ -461,7 +447,7 @@
     <assignments>
         <name>Add_This_Opportunity_ID_to_Filter_Collection</name>
         <label>Add This Opportunity ID to Filter Collection</label>
-        <locationX>7617</locationX>
+        <locationX>8197</locationX>
         <locationY>458</locationY>
         <assignmentItems>
             <assignToReference>collOpenOpportunityIds</assignToReference>
@@ -475,9 +461,48 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Add_Variable_to_Collection</name>
+        <label>Add Variable to Collection</label>
+        <locationX>6365</locationX>
+        <locationY>8060</locationY>
+        <assignmentItems>
+            <assignToReference>coll_Addons_With_Quantity</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>var_Temp_Sku_Product</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Update_Add_On_Quantity_Loop</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>AddSelectedMainProducttoCollection</name>
+        <label>Add Selected Main Product to Collection</label>
+        <locationX>8802</locationX>
+        <locationY>11258</locationY>
+        <assignmentItems>
+            <assignToReference>collSelectedProducts</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>Selected_Main_Products_Loop</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>collAggregateSelectedProducts</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>Selected_Main_Products_Loop</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Selected_Main_Products_Loop</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Assign_Brand_Override_to_Brand_Collection</name>
         <label>Assign Brand Override to Brand Collection</label>
-        <locationX>7441</locationX>
+        <locationX>8021</locationX>
         <locationY>15668</locationY>
         <assignmentItems>
             <assignToReference>varSelectedBrands</assignToReference>
@@ -521,7 +546,7 @@
     <assignments>
         <name>Assign_Brand_to_Brand_Collection</name>
         <label>Assign Brand to Brand Collection</label>
-        <locationX>7705</locationX>
+        <locationX>8285</locationX>
         <locationY>15668</locationY>
         <assignmentItems>
             <assignToReference>varSelectedBrands</assignToReference>
@@ -565,7 +590,7 @@
     <assignments>
         <name>Assign_Brand_to_Brand_Collection_2</name>
         <label>Assign Brand to Brand Collection 2</label>
-        <locationX>7441</locationX>
+        <locationX>8021</locationX>
         <locationY>16160</locationY>
         <assignmentItems>
             <assignToReference>varAggregateBrands</assignToReference>
@@ -595,7 +620,7 @@
     <assignments>
         <name>Assign_Bundle_Id_to_Collection</name>
         <label>Assign Bundle Id to Collection</label>
-        <locationX>7309</locationX>
+        <locationX>7889</locationX>
         <locationY>1988</locationY>
         <assignmentItems>
             <assignToReference>varHasBundles</assignToReference>
@@ -632,7 +657,7 @@
     <assignments>
         <name>Assign_Contract_Id_to_Collection_0</name>
         <label>Assign Contract Id to Collection</label>
-        <locationX>7309</locationX>
+        <locationX>7889</locationX>
         <locationY>3812</locationY>
         <assignmentItems>
             <assignToReference>collSubscriptionContractIds</assignToReference>
@@ -648,7 +673,7 @@
     <assignments>
         <name>Assign_Contract_SKU_to_Collection_0</name>
         <label>Assign Contract SKU to Collection</label>
-        <locationX>7245</locationX>
+        <locationX>7825</locationX>
         <locationY>4436</locationY>
         <assignmentItems>
             <assignToReference>collMainProductIds</assignToReference>
@@ -664,7 +689,7 @@
     <assignments>
         <name>Assign_Create_Brand_Opportunity_to_faultObject</name>
         <label>Assign Create Brand Opportunity to faultObject</label>
-        <locationX>7771</locationX>
+        <locationX>8351</locationX>
         <locationY>18830</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -681,7 +706,7 @@
     <assignments>
         <name>Assign_Create_Opportunity_Promos_to_faultObject</name>
         <label>Assign Create Opportunity Promos to faultObject</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>23480</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -698,7 +723,7 @@
     <assignments>
         <name>Assign_Create_Opportunity_Promos_to_faultObject2</name>
         <label>Assign Create Opportunity Promos to faultObject</label>
-        <locationX>12368</locationX>
+        <locationX>13528</locationX>
         <locationY>14576</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -714,7 +739,7 @@
     <assignments>
         <name>Assign_Create_Opportunity_SKU_Records_to_faultObject</name>
         <label>Assign Create Opportunity SKU Records to faultObject</label>
-        <locationX>14920</locationX>
+        <locationX>16080</locationX>
         <locationY>21656</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -731,7 +756,7 @@
     <assignments>
         <name>Assign_Create_Parent_Opportunity_to_faultObject</name>
         <label>Assign Create Parent Opportunity to faultObject</label>
-        <locationX>7089</locationX>
+        <locationX>7669</locationX>
         <locationY>17000</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -815,8 +840,8 @@
     <assignments>
         <name>Assign_Edited_Product_Ids_to_Collections</name>
         <label>Assign Edited Product Ids to Collections</label>
-        <locationX>7222</locationX>
-        <locationY>10250</locationY>
+        <locationX>8758</locationX>
+        <locationY>10874</locationY>
         <assignmentItems>
             <assignToReference>collSelectedProductIds</assignToReference>
             <operator>Add</operator>
@@ -852,8 +877,8 @@
     <assignments>
         <name>Assign_Filtered_Add_Ons_and_Services_to_Collection</name>
         <label>Assign Filtered Add Ons and Services to Collection</label>
-        <locationX>7134</locationX>
-        <locationY>12350</locationY>
+        <locationX>8228</locationX>
+        <locationY>13142</locationY>
         <assignmentItems>
             <assignToReference>collDisplayProducts</assignToReference>
             <operator>Assign</operator>
@@ -890,8 +915,8 @@
     <assignments>
         <name>Assign_Filtered_Main_Products_to_Filtered_Collection</name>
         <label>Assign Filtered Main Products to Filtered Collection</label>
-        <locationX>6386</locationX>
-        <locationY>9368</locationY>
+        <locationX>7042</locationX>
+        <locationY>9884</locationY>
         <assignmentItems>
             <assignToReference>collFilteredMainProducts</assignToReference>
             <operator>Assign</operator>
@@ -927,7 +952,7 @@
     <assignments>
         <name>Assign_Get_Bundled_Opportunity_SKUs_to_faultObject</name>
         <label>Assign Get Bundled Opportunity SKUs to faultObject</label>
-        <locationX>15448</locationX>
+        <locationX>16608</locationX>
         <locationY>1664</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -944,7 +969,7 @@
     <assignments>
         <name>Assign_Get_Open_Child_Opportunities_to_faultObject</name>
         <label>Assign Get Open Child Opportunities to faultObject</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>674</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -961,7 +986,7 @@
     <assignments>
         <name>Assign_Get_Opportunity_Promos_to_faultObject</name>
         <label>Assign Get Opportunity Promos to faultObject</label>
-        <locationX>15184</locationX>
+        <locationX>16344</locationX>
         <locationY>1772</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -978,7 +1003,7 @@
     <assignments>
         <name>Assign_Get_Opportunity_SKUs_to_faultObject</name>
         <label>Assign Get Opportunity SKUs to faultObject</label>
-        <locationX>15712</locationX>
+        <locationX>16872</locationX>
         <locationY>1556</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -995,7 +1020,7 @@
     <assignments>
         <name>Assign_Get_This_Opportunity_to_faultOjbect</name>
         <label>Assign Get This Opportunity to faultOjbect</label>
-        <locationX>15976</locationX>
+        <locationX>17136</locationX>
         <locationY>242</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -1012,7 +1037,7 @@
     <assignments>
         <name>Assign_Grandfathered_Attributes_to_Collections</name>
         <label>Assign Grandfathered Attributes to Collections</label>
-        <locationX>7245</locationX>
+        <locationX>7825</locationX>
         <locationY>4736</locationY>
         <assignmentItems>
             <assignToReference>collGrandfatheredBrands</assignToReference>
@@ -1035,8 +1060,8 @@
     <assignments>
         <name>Assign_Grandfathered_Main_Products_to_Collection</name>
         <label>Assign Grandfathered Main Products to Collection</label>
-        <locationX>6100</locationX>
-        <locationY>9800</locationY>
+        <locationX>6756</locationX>
+        <locationY>10316</locationY>
         <assignmentItems>
             <assignToReference>collFilteredMainProducts</assignToReference>
             <operator>Add</operator>
@@ -1051,7 +1076,7 @@
     <assignments>
         <name>Assign_Lifetime_Promotion_Id_to_Collection</name>
         <label>Assign Lifetime Promotion Id to Collection</label>
-        <locationX>9765</locationX>
+        <locationX>10925</locationX>
         <locationY>9092</locationY>
         <assignmentItems>
             <assignToReference>collLifetimePromotionIds</assignToReference>
@@ -1067,8 +1092,8 @@
     <assignments>
         <name>Assign_Main_Product_Count_to_Variable</name>
         <label>Assign Main Product Count to Variable</label>
-        <locationX>6386</locationX>
-        <locationY>10484</locationY>
+        <locationX>7042</locationX>
+        <locationY>11000</locationY>
         <assignmentItems>
             <assignToReference>varMainProductCount</assignToReference>
             <operator>AssignCount</operator>
@@ -1083,7 +1108,7 @@
     <assignments>
         <name>Assign_Main_Product_Id_to_Collection</name>
         <label>Assign Main Product Id to Collection</label>
-        <locationX>5716</locationX>
+        <locationX>6296</locationX>
         <locationY>5828</locationY>
         <assignmentItems>
             <assignToReference>collMainProductIds</assignToReference>
@@ -1099,7 +1124,7 @@
     <assignments>
         <name>Assign_Non_Partnership_Lifetime_Product_Sku_Promotion_to_Display_Collection</name>
         <label>Assign Non-Partnership Lifetime Product Sku Promotion to Display Collection</label>
-        <locationX>9958</locationX>
+        <locationX>11118</locationX>
         <locationY>10976</locationY>
         <assignmentItems>
             <assignToReference>collLifetimeProductSkuPromosForSelection</assignToReference>
@@ -1122,7 +1147,7 @@
     <assignments>
         <name>Assign_Non_Partnership_Lifetime_Promo_to_Collection</name>
         <label>Assign Non-Partnership Lifetime Promo to Collection</label>
-        <locationX>9958</locationX>
+        <locationX>11118</locationX>
         <locationY>10376</locationY>
         <assignmentItems>
             <assignToReference>collNonPartnershipLifetimePromos</assignToReference>
@@ -1198,7 +1223,7 @@
     <assignments>
         <name>Assign_Opportunity_Sku_To_Update_Variable_to_Collection</name>
         <label>Assign Opportunity Sku To Update Variable to Collection</label>
-        <locationX>7309</locationX>
+        <locationX>7889</locationX>
         <locationY>22088</locationY>
         <assignmentItems>
             <assignToReference>collOpportunitySkusToUpdate</assignToReference>
@@ -1309,7 +1334,7 @@
     <assignments>
         <name>Assign_Opportunity_SKU_to_Variable_2</name>
         <label>Assign Opportunity SKU to Variable</label>
-        <locationX>7309</locationX>
+        <locationX>7889</locationX>
         <locationY>21980</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySkuToUpdate</assignToReference>
@@ -1376,7 +1401,7 @@
     <assignments>
         <name>Assign_Opportunity_SKU_Variable_to_Collection</name>
         <label>Assign Opportunity SKU Variable to Collection</label>
-        <locationX>8145</locationX>
+        <locationX>8725</locationX>
         <locationY>20120</locationY>
         <assignmentItems>
             <assignToReference>collOpportunitySKUs</assignToReference>
@@ -1392,7 +1417,7 @@
     <assignments>
         <name>Assign_Partnership_Lifetime_Promo_to_Display_Collection</name>
         <label>Assign Partnership Lifetime Promo to Display Collection</label>
-        <locationX>9657</locationX>
+        <locationX>10817</locationX>
         <locationY>9608</locationY>
         <assignmentItems>
             <assignToReference>collLifetimeProductSkuPromosForSelection</assignToReference>
@@ -1415,8 +1440,8 @@
     <assignments>
         <name>Assign_Product_Id_to_Collection</name>
         <label>Assign Product Id to Collection</label>
-        <locationX>4714</locationX>
-        <locationY>9860</locationY>
+        <locationX>5370</locationX>
+        <locationY>9392</locationY>
         <assignmentItems>
             <assignToReference>collSelectedProductIds</assignToReference>
             <operator>Add</operator>
@@ -1431,7 +1456,7 @@
     <assignments>
         <name>Assign_Product_Sku_Promotion_to_Variable</name>
         <label>Assign Product Sku Promotion to Variable</label>
-        <locationX>10126</locationX>
+        <locationX>11286</locationX>
         <locationY>7568</locationY>
         <assignmentItems>
             <assignToReference>varProductSkuPromotion</assignToReference>
@@ -1498,7 +1523,7 @@
     <assignments>
         <name>Assign_SKU_Product_to_Aggregate_Collection</name>
         <label>Assign SKU Product to Aggregate Collection</label>
-        <locationX>13820</locationX>
+        <locationX>14980</locationX>
         <locationY>6560</locationY>
         <assignmentItems>
             <assignToReference>collAggregateSelectedProducts</assignToReference>
@@ -1537,7 +1562,7 @@
     <assignments>
         <name>Assign_This_Opportunity_to_a_Colleciton</name>
         <label>Assign This Opportunity to a Colleciton</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>242</locationY>
         <assignmentItems>
             <assignToReference>collThisOpportunity</assignToReference>
@@ -1583,7 +1608,7 @@
     <assignments>
         <name>Assign_Update_Opportunity_SKUs_with_Promo_Details_to_faultObject</name>
         <label>Assign Update Opportunity SKUs with Promo Details to faultObject</label>
-        <locationX>12632</locationX>
+        <locationX>13792</locationX>
         <locationY>14360</locationY>
         <assignmentItems>
             <assignToReference>faultObject</assignToReference>
@@ -1600,7 +1625,7 @@
     <assignments>
         <name>Assign_Variables_to_Collections</name>
         <label>Assign Variables to Collections</label>
-        <locationX>13842</locationX>
+        <locationX>15002</locationX>
         <locationY>13724</locationY>
         <assignmentItems>
             <assignToReference>collOpportunityPromo</assignToReference>
@@ -1623,7 +1648,7 @@
     <assignments>
         <name>Copy_1_of_Add_Selected_Promotion_SKUs_to_Collection2</name>
         <label>Add Selected Promotion SKUs to Collection</label>
-        <locationX>11664</locationX>
+        <locationX>12824</locationX>
         <locationY>12176</locationY>
         <assignmentItems>
             <assignToReference>collSelectedPromotionSkus</assignToReference>
@@ -1640,7 +1665,7 @@
     <assignments>
         <name>Copy_1_of_Assign_Variables_to_Collections</name>
         <label>Copy 1 of Assign Variables to Collections</label>
-        <locationX>14370</locationX>
+        <locationX>15530</locationX>
         <locationY>13724</locationY>
         <assignmentItems>
             <assignToReference>collOpportunityPromo</assignToReference>
@@ -1679,7 +1704,7 @@
     <assignments>
         <name>No_Main_Product_Selected_Variable_Assigment</name>
         <label>No Main Product Selected Variable Assigment</label>
-        <locationX>5147</locationX>
+        <locationX>5727</locationX>
         <locationY>6620</locationY>
         <assignmentItems>
             <assignToReference>var_No_Main_Product_Selected</assignToReference>
@@ -1710,9 +1735,25 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Reset_Addon_Is_Edited_Variable</name>
+        <label>Reset Addon Is Edited Variable</label>
+        <locationX>5374</locationX>
+        <locationY>10268</locationY>
+        <assignmentItems>
+            <assignToReference>var_Addon_Is_Edited</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <booleanValue>false</booleanValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Selected_Addons_Loop</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Reset_Duration_Validation_Variables2</name>
         <label>Reset Duration Validation Variables</label>
-        <locationX>11532</locationX>
+        <locationX>12692</locationX>
         <locationY>11960</locationY>
         <assignmentItems>
             <assignToReference>varSelectedPromo</assignToReference>
@@ -1746,8 +1787,8 @@
     <assignments>
         <name>Reset_Filtered_Main_Product_Collection</name>
         <label>Reset Filtered Main Product Collection</label>
-        <locationX>6386</locationX>
-        <locationY>10376</locationY>
+        <locationX>7042</locationX>
+        <locationY>10892</locationY>
         <assignmentItems>
             <assignToReference>collFilteredMainProducts</assignToReference>
             <operator>Assign</operator>
@@ -1767,9 +1808,25 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Reset_Main_Product_is_Edited_Variable</name>
+        <label>Reset Main Product is Edited Variable</label>
+        <locationX>8538</locationX>
+        <locationY>11258</locationY>
+        <assignmentItems>
+            <assignToReference>var_Main_Product_Is_Edited</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <booleanValue>false</booleanValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Selected_Main_Products_Loop</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Reset_Opportunity_SKU_Variable</name>
         <label>Reset Opportunity SKU Variable</label>
-        <locationX>8585</locationX>
+        <locationX>9165</locationX>
         <locationY>16676</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku</assignToReference>
@@ -1785,7 +1842,7 @@
     <assignments>
         <name>Reset_Promo_Variables</name>
         <label>Reset Promo Variables</label>
-        <locationX>10253</locationX>
+        <locationX>11413</locationX>
         <locationY>5696</locationY>
         <assignmentItems>
             <assignToReference>varNoLifetimePromotionsFound</assignToReference>
@@ -1843,8 +1900,8 @@
     <assignments>
         <name>Reset_Validation_Variables</name>
         <label>Reset Validation Variables</label>
-        <locationX>4758</locationX>
-        <locationY>8336</locationY>
+        <locationX>5240</locationX>
+        <locationY>8852</locationY>
         <assignmentItems>
             <assignToReference>varQuantityLocked</assignToReference>
             <operator>Assign</operator>
@@ -1939,7 +1996,7 @@
     <assignments>
         <name>Rest_Opportunity_SKU_Variable</name>
         <label>Reset Opportunity SKU Variable</label>
-        <locationX>8277</locationX>
+        <locationX>8857</locationX>
         <locationY>19304</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku</assignToReference>
@@ -1952,7 +2009,7 @@
     <assignments>
         <name>Sales_Approved_Promo_Selected</name>
         <label>Sales_Approved_Promo_Selected</label>
-        <locationX>10410</locationX>
+        <locationX>11570</locationX>
         <locationY>7952</locationY>
         <assignmentItems>
             <assignToReference>var_Sales_Approved_Promo_Selected</assignToReference>
@@ -1975,8 +2032,8 @@
     <assignments>
         <name>Set_Add_On_Exists_Variable</name>
         <label>Set Add On Exists Variable</label>
-        <locationX>4846</locationX>
-        <locationY>10352</locationY>
+        <locationX>5328</locationX>
+        <locationY>10844</locationY>
         <assignmentItems>
             <assignToReference>varAddOnExists</assignToReference>
             <operator>Assign</operator>
@@ -1992,7 +2049,7 @@
     <assignments>
         <name>Set_Add_On_Filtering_Variables</name>
         <label>Set Add On Filtering Variables</label>
-        <locationX>5697</locationX>
+        <locationX>6277</locationX>
         <locationY>6620</locationY>
         <assignmentItems>
             <assignToReference>varSelectedBrand</assignToReference>
@@ -2029,8 +2086,8 @@
     <assignments>
         <name>Set_Brand_Exists_on_Opportunity_Variable</name>
         <label>Set Brand Exists on Opportunity Variable</label>
-        <locationX>6650</locationX>
-        <locationY>8984</locationY>
+        <locationX>7306</locationX>
+        <locationY>9500</locationY>
         <assignmentItems>
             <assignToReference>varBrandExistsOnOpportunity</assignToReference>
             <operator>Assign</operator>
@@ -2045,7 +2102,7 @@
     <assignments>
         <name>Set_Brand_Variable</name>
         <label>Set Brand Variable</label>
-        <locationX>7705</locationX>
+        <locationX>8285</locationX>
         <locationY>17408</locationY>
         <assignmentItems>
             <assignToReference>varBrand</assignToReference>
@@ -2061,7 +2118,7 @@
     <assignments>
         <name>Set_Change_Tier_Variable</name>
         <label>Set Change Tier Variable</label>
-        <locationX>14183</locationX>
+        <locationX>15343</locationX>
         <locationY>5396</locationY>
         <assignmentItems>
             <assignToReference>varChangeTier</assignToReference>
@@ -2077,7 +2134,7 @@
     <assignments>
         <name>Set_Company_Promo_Variable</name>
         <label>Set Company Promo Variable</label>
-        <locationX>9882</locationX>
+        <locationX>11042</locationX>
         <locationY>7952</locationY>
         <assignmentItems>
             <assignToReference>var_Company_Promo_Selected</assignToReference>
@@ -2100,7 +2157,7 @@
     <assignments>
         <name>Set_Contract_SKU_Variable</name>
         <label>Set Contract SKU Variable</label>
-        <locationX>13688</locationX>
+        <locationX>14848</locationX>
         <locationY>6368</locationY>
         <assignmentItems>
             <assignToReference>varChangedContractSku</assignToReference>
@@ -2116,7 +2173,7 @@
     <assignments>
         <name>Set_Discount_Limit_Exceeded_Variable</name>
         <label>Set Discount Limit Exceeded Variable</label>
-        <locationX>13710</locationX>
+        <locationX>14870</locationX>
         <locationY>12842</locationY>
         <assignmentItems>
             <assignToReference>varDiscountMaxExceeded</assignToReference>
@@ -2147,7 +2204,7 @@
     <assignments>
         <name>Set_Discount_Locked_Variable</name>
         <label>Set Discount Locked Variable</label>
-        <locationX>13446</locationX>
+        <locationX>14606</locationX>
         <locationY>12734</locationY>
         <assignmentItems>
             <assignToReference>varDiscountLocked</assignToReference>
@@ -2162,9 +2219,32 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Set_Display_Collection</name>
+        <label>Set Display Collection</label>
+        <locationX>6277</locationX>
+        <locationY>8252</locationY>
+        <assignmentItems>
+            <assignToReference>collDisplayProducts</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>collEmptyProducts</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>collDisplayProducts</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>coll_Addons_With_Quantity</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Sort_Display_Products_Collection</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Set_Display_Products_Collection</name>
         <label>Set Display Products Collection</label>
-        <locationX>5565</locationX>
+        <locationX>6145</locationX>
         <locationY>7052</locationY>
         <assignmentItems>
             <assignToReference>collDisplayProducts</assignToReference>
@@ -2180,7 +2260,7 @@
     <assignments>
         <name>Set_Display_Products_Collection2</name>
         <label>Set Display Products Collection</label>
-        <locationX>6093</locationX>
+        <locationX>6673</locationX>
         <locationY>6404</locationY>
         <assignmentItems>
             <assignToReference>varNoMainProductsValidation</assignToReference>
@@ -2196,7 +2276,7 @@
     <assignments>
         <name>Set_Duration_Locked_Variable2</name>
         <label>Set Duration Locked Variable</label>
-        <locationX>13182</locationX>
+        <locationX>14342</locationX>
         <locationY>12734</locationY>
         <assignmentItems>
             <assignToReference>varDurationLocked</assignToReference>
@@ -2220,7 +2300,7 @@
     <assignments>
         <name>Set_Duration_Override_Validation_Variable_to_True</name>
         <label>Set Duration Override Validation Variable to True</label>
-        <locationX>14150</locationX>
+        <locationX>15310</locationX>
         <locationY>12734</locationY>
         <assignmentItems>
             <assignToReference>varDurationMaxExceeded</assignToReference>
@@ -2251,7 +2331,7 @@
     <assignments>
         <name>Set_HasPromos_Variable</name>
         <label>Set HasPromos Variable</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>3296</locationY>
         <assignmentItems>
             <assignToReference>varHasPromos</assignToReference>
@@ -2267,7 +2347,7 @@
     <assignments>
         <name>Set_HasUnbundledSKUs_Variable</name>
         <label>Set HasUnbundledSKUs Variable</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>2480</locationY>
         <assignmentItems>
             <assignToReference>varHasUnbundledSKUs</assignToReference>
@@ -2348,7 +2428,7 @@
     <assignments>
         <name>Set_No_Add_Ons_Found_Variable</name>
         <label>Set No Add-Ons Found Variable</label>
-        <locationX>5829</locationX>
+        <locationX>6409</locationX>
         <locationY>7052</locationY>
         <assignmentItems>
             <assignToReference>varNoAddons</assignToReference>
@@ -2364,8 +2444,8 @@
     <assignments>
         <name>Set_No_Brand_Selected_Variable</name>
         <label>Set No Brand Selected Variable</label>
-        <locationX>5330</locationX>
-        <locationY>8768</locationY>
+        <locationX>5986</locationX>
+        <locationY>9284</locationY>
         <assignmentItems>
             <assignToReference>var_No_Brand_Selected</assignToReference>
             <operator>Assign</operator>
@@ -2381,8 +2461,8 @@
     <assignments>
         <name>Set_No_Main_Product_Selected_Variable</name>
         <label>Set No Main Product Selected Variable</label>
-        <locationX>7638</locationX>
-        <locationY>8660</locationY>
+        <locationX>8798</locationX>
+        <locationY>9176</locationY>
         <assignmentItems>
             <assignToReference>var_No_Main_Product_Selected</assignToReference>
             <operator>Assign</operator>
@@ -2398,8 +2478,8 @@
     <assignments>
         <name>Set_No_Pricing_Type_Variable</name>
         <label>Set No Pricing Type Variable</label>
-        <locationX>5594</locationX>
-        <locationY>8768</locationY>
+        <locationX>6250</locationX>
+        <locationY>9284</locationY>
         <assignmentItems>
             <assignToReference>var_No_Pricing_Type_Selected</assignToReference>
             <operator>Assign</operator>
@@ -2415,7 +2495,7 @@
     <assignments>
         <name>Set_no_Short_Term_Discounts_Found_Variable_to_True</name>
         <label>Set no Short Term Discounts Found Variable to True</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>7952</locationY>
         <assignmentItems>
             <assignToReference>varNoShortTermDiscountsFound</assignToReference>
@@ -2431,7 +2511,7 @@
     <assignments>
         <name>Set_Opp_Id_Variable</name>
         <label>Set Opp Id Variable</label>
-        <locationX>7089</locationX>
+        <locationX>7669</locationX>
         <locationY>18056</locationY>
         <assignmentItems>
             <assignToReference>varNewOpportunityId</assignToReference>
@@ -2455,7 +2535,7 @@
     <assignments>
         <name>Set_Opp_Id_Variable2</name>
         <label>Set Opp Id Variable</label>
-        <locationX>7243</locationX>
+        <locationX>7823</locationX>
         <locationY>18614</locationY>
         <assignmentItems>
             <assignToReference>varNewOpportunityId</assignToReference>
@@ -2471,7 +2551,7 @@
     <assignments>
         <name>Set_Opportunity_Id_Variable_to_This_Opportunity</name>
         <label>Set Opportunity Id Variable to This Opportunity</label>
-        <locationX>8035</locationX>
+        <locationX>8615</locationX>
         <locationY>17624</locationY>
         <assignmentItems>
             <assignToReference>varNewOpportunityId</assignToReference>
@@ -2487,7 +2567,7 @@
     <assignments>
         <name>Set_Opportunity_Promo_Variable</name>
         <label>Set Opportunity Promo Variable</label>
-        <locationX>7793</locationX>
+        <locationX>8373</locationX>
         <locationY>23072</locationY>
         <assignmentItems>
             <assignToReference>varOpportunityPromo.CurrencyIsoCode</assignToReference>
@@ -2503,7 +2583,7 @@
     <assignments>
         <name>Set_Opportunity_SKU_Updates_Lifetime</name>
         <label>Set Opportunity SKU Updates - Lifetime</label>
-        <locationX>14370</locationX>
+        <locationX>15530</locationX>
         <locationY>13616</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku</assignToReference>
@@ -2603,7 +2683,7 @@
     <assignments>
         <name>Set_Opportunity_SKU_Updates_Short_Term</name>
         <label>Set Opportunity SKU Updates - Short-Term</label>
-        <locationX>13842</locationX>
+        <locationX>15002</locationX>
         <locationY>13616</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku</assignToReference>
@@ -2703,7 +2783,7 @@
     <assignments>
         <name>Set_Opportunity_SKU_Variable</name>
         <label>Set Opportunity SKU Variable</label>
-        <locationX>8145</locationX>
+        <locationX>8725</locationX>
         <locationY>19520</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku.Opportunity__c</assignToReference>
@@ -2789,7 +2869,7 @@
     <assignments>
         <name>Set_Parent_Opportunity_Id_Variable_2</name>
         <label>Set Parent Opportunity Id Variable</label>
-        <locationX>6825</locationX>
+        <locationX>7405</locationX>
         <locationY>17108</locationY>
         <assignmentItems>
             <assignToReference>varParentOpportunityId</assignToReference>
@@ -2805,7 +2885,7 @@
     <assignments>
         <name>Set_Parent_Opportunity_Variable</name>
         <label>Set Parent Opportunity Variable</label>
-        <locationX>6297</locationX>
+        <locationX>6877</locationX>
         <locationY>16676</locationY>
         <assignmentItems>
             <assignToReference>varParentOpportunityId</assignToReference>
@@ -2821,7 +2901,7 @@
     <assignments>
         <name>Set_Parent_Opportunity_Variable_2</name>
         <label>Set Parent Opportunity Variable</label>
-        <locationX>6825</locationX>
+        <locationX>7405</locationX>
         <locationY>16784</locationY>
         <assignmentItems>
             <assignToReference>varParentOpportunity.Id</assignToReference>
@@ -3040,7 +3120,7 @@
     <assignments>
         <name>Set_Parent_Opportunity_Variable_to_this_Opportunity</name>
         <label>Set Parent Opportunity Variable to this Opportunity</label>
-        <locationX>6561</locationX>
+        <locationX>7141</locationX>
         <locationY>16676</locationY>
         <assignmentItems>
             <assignToReference>varParentOpportunityId</assignToReference>
@@ -3056,7 +3136,7 @@
     <assignments>
         <name>Set_Parent_Variable</name>
         <label>Set Parent Variable</label>
-        <locationX>7089</locationX>
+        <locationX>7669</locationX>
         <locationY>458</locationY>
         <assignmentItems>
             <assignToReference>varThisOppIsParent</assignToReference>
@@ -3072,7 +3152,7 @@
     <assignments>
         <name>Set_Promotion_on_Opportunity_SKU_Variable</name>
         <label>Set Promotion on Opportunity SKU Variable</label>
-        <locationX>8233</locationX>
+        <locationX>8813</locationX>
         <locationY>19844</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku.Lifetime_Promotion__c</assignToReference>
@@ -3095,8 +3175,8 @@
     <assignments>
         <name>Set_Quantity_Locked_Variable</name>
         <label>Set Quantity Locked Variable</label>
-        <locationX>4714</locationX>
-        <locationY>8768</locationY>
+        <locationX>5154</locationX>
+        <locationY>9284</locationY>
         <assignmentItems>
             <assignToReference>varQuantityLocked</assignToReference>
             <operator>Assign</operator>
@@ -3111,8 +3191,8 @@
     <assignments>
         <name>Set_Quantity_Locked_Variable_MainProduct</name>
         <label>Set Quantity Locked Variable</label>
-        <locationX>7222</locationX>
-        <locationY>9692</locationY>
+        <locationX>8318</locationX>
+        <locationY>10208</locationY>
         <assignmentItems>
             <assignToReference>varQuantityLocked</assignToReference>
             <operator>Assign</operator>
@@ -3128,8 +3208,8 @@
     <assignments>
         <name>Set_Quantity_on_Loop_Item</name>
         <label>Set Quantity on Loop Item</label>
-        <locationX>6474</locationX>
-        <locationY>10184</locationY>
+        <locationX>7130</locationX>
+        <locationY>10700</locationY>
         <assignmentItems>
             <assignToReference>varSkuProduct</assignToReference>
             <operator>Assign</operator>
@@ -3156,9 +3236,32 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Set_Quantity_to_1</name>
+        <label>Set Quantity to 1</label>
+        <locationX>6365</locationX>
+        <locationY>7952</locationY>
+        <assignmentItems>
+            <assignToReference>var_Temp_Sku_Product</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Update_Add_On_Quantity_Loop</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>var_Temp_Sku_Product.Quantity__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <numberValue>1.0</numberValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Add_Variable_to_Collection</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Set_Remaining_Opportunity_Promo_Fields</name>
         <label>Set Remaining Opportunity Promo Fields</label>
-        <locationX>7881</locationX>
+        <locationX>8461</locationX>
         <locationY>22796</locationY>
         <assignmentItems>
             <assignToReference>varOpportunityPromo</assignToReference>
@@ -3225,8 +3328,8 @@
     <assignments>
         <name>Set_Variables</name>
         <label>Set Variables</label>
-        <locationX>7266</locationX>
-        <locationY>9260</locationY>
+        <locationX>8360</locationX>
+        <locationY>9776</locationY>
         <assignmentItems>
             <assignToReference>collRequiredProductIds</assignToReference>
             <operator>Assign</operator>
@@ -3255,7 +3358,7 @@
     <assignments>
         <name>Single_Brand_Assign_Opportunity_SKU_Variable_to_Collection</name>
         <label>Single Brand Assign Opportunity SKU Variable to Collection</label>
-        <locationX>8585</locationX>
+        <locationX>9165</locationX>
         <locationY>17384</locationY>
         <assignmentItems>
             <assignToReference>collOpportunitySKUs</assignToReference>
@@ -3271,7 +3374,7 @@
     <assignments>
         <name>Single_Brand_Set_Opportunity_SKU_Variable</name>
         <label>Single Brand Set Opportunity SKU Variable</label>
-        <locationX>8585</locationX>
+        <locationX>9165</locationX>
         <locationY>16784</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku.Opportunity__c</assignToReference>
@@ -3357,7 +3460,7 @@
     <assignments>
         <name>Single_Brand_Set_Promotion_on_Opportunity_SKU_Variable</name>
         <label>Single Brand Set Promotion on Opportunity SKU Variable</label>
-        <locationX>8673</locationX>
+        <locationX>9253</locationX>
         <locationY>17108</locationY>
         <assignmentItems>
             <assignToReference>varOpportunitySku.Lifetime_Promotion__c</assignToReference>
@@ -3380,7 +3483,7 @@
     <assignments>
         <name>Update_Opportunity_SKU_Collection</name>
         <label>Update Opportunity SKU Collection</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>21356</locationY>
         <assignmentItems>
             <assignToReference>collOpportunitySKUs</assignToReference>
@@ -3396,7 +3499,7 @@
     <assignments>
         <name>Update_Opportunity_SKU_with_Bundle_Attributes</name>
         <label>Update Opportunity SKU with Bundle Attributes</label>
-        <locationX>7749</locationX>
+        <locationX>8329</locationX>
         <locationY>20996</locationY>
         <assignmentItems>
             <assignToReference>Apply_Bundle_Attributes_Loop.Bundle__c</assignToReference>
@@ -3443,7 +3546,7 @@
         <name>Filter_Addons</name>
         <elementSubtype>FilterCollectionProcessor</elementSubtype>
         <label>Filter Addons</label>
-        <locationX>5697</locationX>
+        <locationX>6277</locationX>
         <locationY>6836</locationY>
         <assignNextValueToReference>currentItem_Filter_Addons</assignNextValueToReference>
         <collectionProcessorType>FilterCollectionProcessor</collectionProcessorType>
@@ -3464,8 +3567,8 @@
         <name>Filter_Main_Product_Collection_by_Selected_Brand</name>
         <elementSubtype>FilterCollectionProcessor</elementSubtype>
         <label>Filter Main Product Collection by Selected Brand</label>
-        <locationX>6386</locationX>
-        <locationY>9260</locationY>
+        <locationX>7042</locationX>
+        <locationY>9776</locationY>
         <assignNextValueToReference>currentItem_Filter_Main_Product_Collection_by_Selected_Brand</assignNextValueToReference>
         <collectionProcessorType>FilterCollectionProcessor</collectionProcessorType>
         <collectionReference>collAllProducts</collectionReference>
@@ -3499,8 +3602,8 @@
         <name>Sort_Display_Products_Collection</name>
         <elementSubtype>SortCollectionProcessor</elementSubtype>
         <label>Sort Display Products Collection</label>
-        <locationX>5697</locationX>
-        <locationY>7844</locationY>
+        <locationX>6277</locationX>
+        <locationY>8360</locationY>
         <collectionProcessorType>SortCollectionProcessor</collectionProcessorType>
         <collectionReference>collDisplayProducts</collectionReference>
         <connector>
@@ -3517,7 +3620,7 @@
         <name>Sort_Opportunity_SKUs_by_Name</name>
         <elementSubtype>SortCollectionProcessor</elementSubtype>
         <label>Sort Opportunity SKUs by Name</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>2588</locationY>
         <collectionProcessorType>SortCollectionProcessor</collectionProcessorType>
         <collectionReference>collUnbundledSkus</collectionReference>
@@ -3540,7 +3643,7 @@
     <decisions>
         <name>Action_Type</name>
         <label>Action Type</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>5288</locationY>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
@@ -3652,7 +3755,7 @@
     <decisions>
         <name>Add_to_Selected_Opp</name>
         <label>Add to Selected Opp</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>17948</locationY>
         <defaultConnector>
             <targetReference>Get_Open_Child_Opportunity</targetReference>
@@ -3677,7 +3780,7 @@
     <decisions>
         <name>Are_Add_On_Products_Found</name>
         <label>Are Add-On Products Found?</label>
-        <locationX>5697</locationX>
+        <locationX>6277</locationX>
         <locationY>6944</locationY>
         <defaultConnector>
             <targetReference>Set_No_Add_Ons_Found_Variable</targetReference>
@@ -3727,8 +3830,8 @@
     <decisions>
         <name>Are_Main_Products_Available</name>
         <label>Are Main Products Available?</label>
-        <locationX>6386</locationX>
-        <locationY>10592</locationY>
+        <locationX>7042</locationX>
+        <locationY>11108</locationY>
         <defaultConnector>
             <targetReference>No_Main_Products_Found_Screen</targetReference>
         </defaultConnector>
@@ -3753,7 +3856,7 @@
     <decisions>
         <name>Are_Non_Parntership_Lifetime_Product_Sku_Promos_Found</name>
         <label>Are Non-Parntership Lifetime Product Sku Promos Found?</label>
-        <locationX>9978</locationX>
+        <locationX>11138</locationX>
         <locationY>10760</locationY>
         <defaultConnector>
             <targetReference>Select_Promotion_Screen</targetReference>
@@ -3778,7 +3881,7 @@
     <decisions>
         <name>Are_Non_Partnership_Promos_Found</name>
         <label>Are Non-Partnership Promos Found?</label>
-        <locationX>9978</locationX>
+        <locationX>11138</locationX>
         <locationY>10160</locationY>
         <defaultConnector>
             <targetReference>Get_Non_Parntership_Lifetime_Product_Sku_Promos</targetReference>
@@ -3828,7 +3931,7 @@
     <decisions>
         <name>Are_Promotions_Edited</name>
         <label>Are Promotions Edited?</label>
-        <locationX>11532</locationX>
+        <locationX>12692</locationX>
         <locationY>12068</locationY>
         <defaultConnector>
             <targetReference>Copy_1_of_Add_Selected_Promotion_SKUs_to_Collection2</targetReference>
@@ -3904,7 +4007,7 @@
     <decisions>
         <name>Bundle_SKU_Product_Match</name>
         <label>Bundle SKU Product Match</label>
-        <locationX>7881</locationX>
+        <locationX>8461</locationX>
         <locationY>20888</locationY>
         <defaultConnector>
             <targetReference>Apply_Bundle_Attributes_Sub_Loop</targetReference>
@@ -3929,7 +4032,7 @@
     <decisions>
         <name>Bundles_on_Opportunity</name>
         <label>Bundles on Opportunity?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>1772</locationY>
         <defaultConnector>
             <targetReference>Opportunity_SKUs_Exist</targetReference>
@@ -3954,7 +4057,7 @@
     <decisions>
         <name>Check_Discount_Limit</name>
         <label>Check Discount Limit</label>
-        <locationX>13842</locationX>
+        <locationX>15002</locationX>
         <locationY>12734</locationY>
         <defaultConnector>
             <targetReference>SKU_Product_Promo_Match_Loop</targetReference>
@@ -3993,7 +4096,7 @@
     <decisions>
         <name>Check_if_Parent_Exists</name>
         <label>Check if Parent Exists</label>
-        <locationX>6561</locationX>
+        <locationX>7141</locationX>
         <locationY>16568</locationY>
         <defaultConnector>
             <targetReference>Get_Parent_Opportunity_Record_Type</targetReference>
@@ -4033,7 +4136,7 @@
     <decisions>
         <name>Check_Override_Duration</name>
         <label>Check Override Duration</label>
-        <locationX>13490</locationX>
+        <locationX>14650</locationX>
         <locationY>12626</locationY>
         <defaultConnector>
             <targetReference>Set_Duration_Override_Validation_Variable_to_True</targetReference>
@@ -4181,7 +4284,7 @@
     <decisions>
         <name>Contract_SKU_Found</name>
         <label>Contract SKU Found?</label>
-        <locationX>13820</locationX>
+        <locationX>14980</locationX>
         <locationY>6260</locationY>
         <defaultConnector>
             <targetReference>Assign_SKU_Product_to_Aggregate_Collection</targetReference>
@@ -4206,7 +4309,7 @@
     <decisions>
         <name>Contract_SKUs_Found_0</name>
         <label>Contract SKUs Found?</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>4112</locationY>
         <defaultConnector>
             <targetReference>Product_Selection</targetReference>
@@ -4231,8 +4334,8 @@
     <decisions>
         <name>dec_Add_on_Selection</name>
         <label>Add-on Selection Made?</label>
-        <locationX>5692</locationX>
-        <locationY>8228</locationY>
+        <locationX>6272</locationX>
+        <locationY>8744</locationY>
         <defaultConnector>
             <isGoTo>true</isGoTo>
             <targetReference>Get_Opportunity</targetReference>
@@ -4361,8 +4464,8 @@
     <decisions>
         <name>dec_Brand_Screen_Action</name>
         <label>Brand Screen Action</label>
-        <locationX>5726</locationX>
-        <locationY>8660</locationY>
+        <locationX>6382</locationX>
+        <locationY>9176</locationY>
         <defaultConnector>
             <targetReference>Check_if_Opportunity_Already_Has_Brand_Loop</targetReference>
         </defaultConnector>
@@ -4417,8 +4520,8 @@
     <decisions>
         <name>dec_Check_if_Add_On_Already_Exists_on_Opportunity</name>
         <label>Check if Add On Already Exists on Opportunity</label>
-        <locationX>4978</locationX>
-        <locationY>10244</locationY>
+        <locationX>5460</locationX>
+        <locationY>10736</locationY>
         <defaultConnector>
             <targetReference>Check_for_Existing_Add_On_Loop</targetReference>
         </defaultConnector>
@@ -4468,8 +4571,8 @@
     <decisions>
         <name>dec_Deleted_Opportunity_SKUs</name>
         <label>Deleted Opportunity SKUs?</label>
-        <locationX>7266</locationX>
-        <locationY>8660</locationY>
+        <locationX>8360</locationX>
+        <locationY>9176</locationY>
         <defaultConnector>
             <targetReference>Set_Variables</targetReference>
         </defaultConnector>
@@ -4491,10 +4594,35 @@
         </rules>
     </decisions>
     <decisions>
+        <name>dec_Does_Edited_Product_Match_Selected_Product</name>
+        <label>Does Edited Product Match Selected Product?</label>
+        <locationX>5726</locationX>
+        <locationY>9776</locationY>
+        <defaultConnector>
+            <targetReference>Edited_Addons_Loop</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>No</defaultConnectorLabel>
+        <rules>
+            <name>dec_Does_Edited_Product_Match_Selected_Product_Yes</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Selected_Addons_Loop.Id</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>Edited_Addons_Loop.Id</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Add_Edited_Addon_Id_to_Collection</targetReference>
+            </connector>
+            <label>Yes</label>
+        </rules>
+    </decisions>
+    <decisions>
         <name>dec_Does_Opportunity_Already_have_Brand_Sku</name>
         <label>Does Opportunity Already have Brand Sku?</label>
-        <locationX>6694</locationX>
-        <locationY>8876</locationY>
+        <locationX>7350</locationX>
+        <locationY>9392</locationY>
         <defaultConnector>
             <targetReference>Check_if_Opportunity_Already_Has_Brand_Loop</targetReference>
         </defaultConnector>
@@ -4538,10 +4666,35 @@
         </rules>
     </decisions>
     <decisions>
+        <name>dec_Does_Selected_Main_Product_Match_Edited_Main_Product</name>
+        <label>Does Selected Main Product Match Edited Main Product?</label>
+        <locationX>8890</locationX>
+        <locationY>10766</locationY>
+        <defaultConnector>
+            <targetReference>Edited_Main_Products_Loop</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>No</defaultConnectorLabel>
+        <rules>
+            <name>dec_Does_Selected_Main_Product_Match_Edited_Main_Product_Yes</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Selected_Main_Products_Loop.Id</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>Edited_Main_Products_Loop.Id</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Assign_Edited_Product_Ids_to_Collections</targetReference>
+            </connector>
+            <label>Yes</label>
+        </rules>
+    </decisions>
+    <decisions>
         <name>dec_Is_Addon_Edited</name>
         <label>Is Addon Edited?</label>
-        <locationX>4758</locationX>
-        <locationY>8444</locationY>
+        <locationX>5240</locationX>
+        <locationY>8960</locationY>
         <defaultConnector>
             <targetReference>Is_Addon_Selected</targetReference>
         </defaultConnector>
@@ -4565,8 +4718,8 @@
     <decisions>
         <name>dec_Is_Edited_Addon_Quantity_Locked</name>
         <label>Is Edited Addon Quantity Locked?</label>
-        <locationX>4846</locationX>
-        <locationY>8660</locationY>
+        <locationX>5286</locationX>
+        <locationY>9176</locationY>
         <defaultConnector>
             <targetReference>Check_for_Quantity_Lock_on_Edited_Addon_Loop</targetReference>
         </defaultConnector>
@@ -4590,7 +4743,7 @@
     <decisions>
         <name>dec_Is_Lifetime_Promo_Already_Added</name>
         <label>Is Lifetime Promo Already Added?</label>
-        <locationX>14238</locationX>
+        <locationX>15398</locationX>
         <locationY>13508</locationY>
         <defaultConnector>
             <targetReference>Set_Opportunity_SKU_Updates_Lifetime</targetReference>
@@ -4615,7 +4768,7 @@
     <decisions>
         <name>dec_Is_Lifetime_Promo_Selected</name>
         <label>Is Lifetime Promo Selected?</label>
-        <locationX>11862</locationX>
+        <locationX>13022</locationX>
         <locationY>11552</locationY>
         <defaultConnector>
             <targetReference>Short_Term_Promo_Type</targetReference>
@@ -4640,7 +4793,7 @@
     <decisions>
         <name>dec_Is_Short_Term_Promo_Already_Added</name>
         <label>Is Short Term Promo Already Added?</label>
-        <locationX>13710</locationX>
+        <locationX>14870</locationX>
         <locationY>13508</locationY>
         <defaultConnector>
             <targetReference>Set_Opportunity_SKU_Updates_Short_Term</targetReference>
@@ -4691,8 +4844,8 @@
     <decisions>
         <name>dec_Main_Product_Actions</name>
         <label>Main Product Actions</label>
-        <locationX>6589</locationX>
-        <locationY>8444</locationY>
+        <locationX>7480</locationX>
+        <locationY>8960</locationY>
         <defaultConnector>
             <targetReference>dec_Main_Product_Selected</targetReference>
         </defaultConnector>
@@ -4716,7 +4869,7 @@
     <decisions>
         <name>dec_Main_Product_for_Add_Ons_Actions</name>
         <label>Main Product for Add Ons Actions</label>
-        <locationX>5290</locationX>
+        <locationX>5870</locationX>
         <locationY>6512</locationY>
         <defaultConnector>
             <targetReference>Set_Add_On_Filtering_Variables</targetReference>
@@ -4757,8 +4910,8 @@
     <decisions>
         <name>dec_Main_Product_Quantity_is_Locked</name>
         <label>Main Product Quantity is Locked?</label>
-        <locationX>7354</locationX>
-        <locationY>9584</locationY>
+        <locationX>8450</locationX>
+        <locationY>10100</locationY>
         <defaultConnector>
             <targetReference>Edited_Main_Product_Quantity_Locked_Loop</targetReference>
         </defaultConnector>
@@ -4782,8 +4935,8 @@
     <decisions>
         <name>dec_Main_Product_Selected</name>
         <label>Main Product Selected?</label>
-        <locationX>7452</locationX>
-        <locationY>8552</locationY>
+        <locationX>8579</locationX>
+        <locationY>9068</locationY>
         <defaultConnector>
             <targetReference>Set_No_Main_Product_Selected_Variable</targetReference>
         </defaultConnector>
@@ -4814,8 +4967,8 @@
     <decisions>
         <name>dec_Opportunity_SKUs_to_Delete_Found</name>
         <label>Opportunity SKUs to Delete Found?</label>
-        <locationX>7112</locationX>
-        <locationY>8876</locationY>
+        <locationX>8206</locationX>
+        <locationY>9392</locationY>
         <defaultConnector>
             <targetReference>Set_Variables</targetReference>
         </defaultConnector>
@@ -4839,7 +4992,7 @@
     <decisions>
         <name>dec_Promo_Action</name>
         <label>Promo Action</label>
-        <locationX>10253</locationX>
+        <locationX>11413</locationX>
         <locationY>5912</locationY>
         <defaultConnector>
             <targetReference>Get_Existing_Opportunity_Promos</targetReference>
@@ -4865,8 +5018,8 @@
     <decisions>
         <name>dec_Required_Products_Action</name>
         <label>Required Products Action</label>
-        <locationX>7070</locationX>
-        <locationY>11558</locationY>
+        <locationX>8164</locationX>
+        <locationY>12350</locationY>
         <defaultConnector>
             <targetReference>Required_Products_Loop</targetReference>
         </defaultConnector>
@@ -4891,7 +5044,7 @@
     <decisions>
         <name>dec_Select_Promo_Action</name>
         <label>Select Promo Action</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>11444</locationY>
         <defaultConnector>
             <targetReference>dec_Is_Lifetime_Promo_Selected</targetReference>
@@ -4919,6 +5072,56 @@
                 <targetReference>Reset_Promo_Variables</targetReference>
             </connector>
             <label>Back</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>dec_Was_Selected_Main_Product_Added_to_Collection</name>
+        <label>Was Selected Main Product Added to Collection?</label>
+        <locationX>8670</locationX>
+        <locationY>11150</locationY>
+        <defaultConnector>
+            <targetReference>AddSelectedMainProducttoCollection</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>No</defaultConnectorLabel>
+        <rules>
+            <name>dec_Was_Selected_Main_Product_Added_to_Collection_Yes</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>var_Main_Product_Is_Edited</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Reset_Main_Product_is_Edited_Variable</targetReference>
+            </connector>
+            <label>Yes</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>dec_Was_Selected_Product_Edited</name>
+        <label>Was Selected Product Edited</label>
+        <locationX>5506</locationX>
+        <locationY>10160</locationY>
+        <defaultConnector>
+            <targetReference>Add_Selected_Product_to_Collection</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>No</defaultConnectorLabel>
+        <rules>
+            <name>dec_Was_Selected_Product_Edited_Yes</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>var_Addon_Is_Edited</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Reset_Addon_Is_Edited_Variable</targetReference>
+            </connector>
+            <label>Yes</label>
         </rules>
     </decisions>
     <decisions>
@@ -5024,7 +5227,7 @@
     <decisions>
         <name>Do_Partnership_Discounts_Exist</name>
         <label>Do Partnership Discounts Exist?</label>
-        <locationX>9819</locationX>
+        <locationX>10979</locationX>
         <locationY>8468</locationY>
         <defaultConnector>
             <targetReference>Get_All_Non_Partnership_Lifetime_Promotions</targetReference>
@@ -5049,7 +5252,7 @@
     <decisions>
         <name>Does_Open_Child_Opportunity_Exist</name>
         <label>Does Open Child Opportunity Exist?</label>
-        <locationX>7375</locationX>
+        <locationX>7955</locationX>
         <locationY>18506</locationY>
         <defaultConnector>
             <targetReference>Get_Opportunity_Record_Types</targetReference>
@@ -5074,7 +5277,7 @@
     <decisions>
         <name>Does_Opportunity_have_a_Partnership</name>
         <label>Does Opportunity have a Partnership?</label>
-        <locationX>9978</locationX>
+        <locationX>11138</locationX>
         <locationY>8252</locationY>
         <defaultConnector>
             <targetReference>Get_All_Non_Partnership_Lifetime_Promotions</targetReference>
@@ -5099,7 +5302,7 @@
     <decisions>
         <name>Does_Product_Match_Opportunity_Promo</name>
         <label>Does Product Match Opportunity Promo?</label>
-        <locationX>8013</locationX>
+        <locationX>8593</locationX>
         <locationY>22688</locationY>
         <defaultConnector>
             <targetReference>Opportunity_Promos_Loop</targetReference>
@@ -5124,7 +5327,7 @@
     <decisions>
         <name>Does_SKU_Product_have_Record_Type_Override</name>
         <label>Does SKU Product have Record Type Override?</label>
-        <locationX>7573</locationX>
+        <locationX>8153</locationX>
         <locationY>15560</locationY>
         <defaultConnector>
             <targetReference>Assign_Brand_to_Brand_Collection</targetReference>
@@ -5156,10 +5359,10 @@
     <decisions>
         <name>Grandfathered1</name>
         <label>Grandfathered?</label>
-        <locationX>5697</locationX>
+        <locationX>6277</locationX>
         <locationY>7244</locationY>
         <defaultConnector>
-            <targetReference>Sort_Display_Products_Collection</targetReference>
+            <targetReference>Update_Add_On_Quantity_Loop</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
@@ -5188,10 +5391,10 @@
     <decisions>
         <name>Grandfathered_Add_Ons_Found</name>
         <label>Grandfathered Add Ons Found?</label>
-        <locationX>5543</locationX>
+        <locationX>6123</locationX>
         <locationY>7460</locationY>
         <defaultConnector>
-            <targetReference>Sort_Display_Products_Collection</targetReference>
+            <targetReference>Update_Add_On_Quantity_Loop</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
@@ -5213,8 +5416,8 @@
     <decisions>
         <name>Grandfathered_Products_Found</name>
         <label>Grandfathered Products Found?</label>
-        <locationX>6232</locationX>
-        <locationY>9692</locationY>
+        <locationX>6888</locationX>
+        <locationY>10208</locationY>
         <defaultConnector>
             <targetReference>Set_Quantity_on_Filtered_Products_Loop</targetReference>
         </defaultConnector>
@@ -5238,8 +5441,8 @@
     <decisions>
         <name>Has_Add_Ons</name>
         <label>Has Add Ons?</label>
-        <locationX>7266</locationX>
-        <locationY>12242</locationY>
+        <locationX>8360</locationX>
+        <locationY>13034</locationY>
         <defaultConnector>
             <targetReference>Get_Opportunity</targetReference>
         </defaultConnector>
@@ -5263,7 +5466,7 @@
     <decisions>
         <name>Has_Opportunity_Promos</name>
         <label>Has Opportunity Promos?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>3188</locationY>
         <defaultConnector>
             <targetReference>Get_Contract_Subscriptions_0</targetReference>
@@ -5288,7 +5491,7 @@
     <decisions>
         <name>Have_Opportunity_Promos</name>
         <label>Have Opportunity Promos?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>23264</locationY>
         <defaultConnector>
             <targetReference>Navigate_to_New_Parent_Opportunity</targetReference>
@@ -5338,7 +5541,7 @@
     <decisions>
         <name>Is_Active_Contract_Found_0</name>
         <label>Is Active Contract Found?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>3596</locationY>
         <defaultConnector>
             <targetReference>Product_Selection</targetReference>
@@ -5363,8 +5566,8 @@
     <decisions>
         <name>Is_Addon_Selected</name>
         <label>Is Addon Selected?</label>
-        <locationX>4758</locationX>
-        <locationY>9536</locationY>
+        <locationX>5414</locationX>
+        <locationY>9068</locationY>
         <defaultConnector>
             <targetReference>Check_for_Existing_Add_On_Loop</targetReference>
         </defaultConnector>
@@ -5388,7 +5591,7 @@
     <decisions>
         <name>Is_Bundle_Selection</name>
         <label>Is Bundle Selection</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>20564</locationY>
         <defaultConnector>
             <targetReference>Create_Opportunity_SKU_Records</targetReference>
@@ -5413,7 +5616,7 @@
     <decisions>
         <name>Is_Contract_SKU_a_Main_Product_Type_0</name>
         <label>Is Contract SKU a Main Product Type?</label>
-        <locationX>7377</locationX>
+        <locationX>7957</locationX>
         <locationY>4328</locationY>
         <defaultConnector>
             <targetReference>Is_SKU_Product_Grandfathered</targetReference>
@@ -5439,7 +5642,7 @@
         <description>Checks if current loop item&#39;s brand is the same as Opportunity that started transaction in order to skip creating an Opportunity for the brand.</description>
         <name>Is_Current_Opportunity_Brand</name>
         <label>Is Current Opportunity Brand?</label>
-        <locationX>7705</locationX>
+        <locationX>8285</locationX>
         <locationY>17516</locationY>
         <defaultConnector>
             <targetReference>Set_Opportunity_Id_Variable_to_This_Opportunity</targetReference>
@@ -5464,8 +5667,8 @@
     <decisions>
         <name>Is_Grandfathered</name>
         <label>Is Grandfathered?</label>
-        <locationX>6386</locationX>
-        <locationY>9476</locationY>
+        <locationX>7042</locationX>
+        <locationY>9992</locationY>
         <defaultConnector>
             <targetReference>Set_Quantity_on_Filtered_Products_Loop</targetReference>
         </defaultConnector>
@@ -5496,7 +5699,7 @@
     <decisions>
         <name>Is_Lifetime_Selected</name>
         <label>Is Lifetime Discount Selected?</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>8144</locationY>
         <defaultConnector>
             <targetReference>Select_Promotion_Screen</targetReference>
@@ -5521,7 +5724,7 @@
     <decisions>
         <name>Is_Parent_Opportunity</name>
         <label>Is Parent Opportunity?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>350</locationY>
         <defaultConnector>
             <targetReference>Add_This_Opportunity_ID_to_Filter_Collection</targetReference>
@@ -5546,7 +5749,7 @@
     <decisions>
         <name>Is_Short_Term_Selected</name>
         <label>Is Short-Term Selected?</label>
-        <locationX>12340</locationX>
+        <locationX>13500</locationX>
         <locationY>6620</locationY>
         <defaultConnector>
             <isGoTo>true</isGoTo>
@@ -5572,7 +5775,7 @@
     <decisions>
         <name>Is_SKU_Main_Product</name>
         <label>Is SKU Main Product?</label>
-        <locationX>5848</locationX>
+        <locationX>6428</locationX>
         <locationY>5720</locationY>
         <defaultConnector>
             <targetReference>Assign_Main_Product_Loop</targetReference>
@@ -5597,7 +5800,7 @@
     <decisions>
         <name>Is_SKU_Product_Grandfathered</name>
         <label>Is SKU Product Grandfathered?</label>
-        <locationX>7377</locationX>
+        <locationX>7957</locationX>
         <locationY>4628</locationY>
         <defaultConnector>
             <targetReference>Contract_SKUs_Assignment_Loop_0</targetReference>
@@ -5647,7 +5850,7 @@
     <decisions>
         <name>Lifetime_Promotions_Found</name>
         <label>Lifetime Promotions Found?</label>
-        <locationX>9677</locationX>
+        <locationX>10837</locationX>
         <locationY>9392</locationY>
         <defaultConnector>
             <targetReference>Get_All_Non_Partnership_Lifetime_Promotions</targetReference>
@@ -5672,7 +5875,7 @@
     <decisions>
         <name>Main_Products_Exist</name>
         <label>Main Products Exist?</label>
-        <locationX>5692</locationX>
+        <locationX>6272</locationX>
         <locationY>6296</locationY>
         <defaultConnector>
             <targetReference>Set_Display_Products_Collection2</targetReference>
@@ -5697,7 +5900,7 @@
     <decisions>
         <name>Main_Products_Exist_5</name>
         <label>Main Products Exist?</label>
-        <locationX>14183</locationX>
+        <locationX>15343</locationX>
         <locationY>5612</locationY>
         <defaultConnector>
             <targetReference>No_Products_to_Upgrade_Screen</targetReference>
@@ -5722,7 +5925,7 @@
     <decisions>
         <name>Multiple_Brands</name>
         <label>Multiple Brands?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>16460</locationY>
         <defaultConnector>
             <targetReference>Single_Brand_Product_Loop</targetReference>
@@ -5761,7 +5964,7 @@
     <decisions>
         <name>Navigate_to_New_Parent_Opportunity</name>
         <label>Navigate to New Parent Opportunity?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>23762</locationY>
         <defaultConnectorLabel>No</defaultConnectorLabel>
         <rules>
@@ -5783,7 +5986,7 @@
     <decisions>
         <name>Open_Opp_Found</name>
         <label>Open Opp Found?</label>
-        <locationX>7375</locationX>
+        <locationX>7955</locationX>
         <locationY>17732</locationY>
         <defaultConnector>
             <targetReference>Get_Open_Child_Opportunity</targetReference>
@@ -5808,7 +6011,7 @@
     <decisions>
         <name>Open_Opportunities_Exist</name>
         <label>Open Opportunities Exist?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>956</locationY>
         <defaultConnector>
             <targetReference>Get_Opportunity_SKUs</targetReference>
@@ -5833,7 +6036,7 @@
     <decisions>
         <name>Opportunity_Promos_Exist2</name>
         <label>Opportunity Promos Exist?</label>
-        <locationX>12340</locationX>
+        <locationX>13500</locationX>
         <locationY>6128</locationY>
         <defaultConnector>
             <targetReference>Is_Short_Term_Selected</targetReference>
@@ -5880,7 +6083,7 @@
     <decisions>
         <name>Opportunity_SKUs_Exist</name>
         <label>Opportunity SKUs Exist?</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>2372</locationY>
         <defaultConnector>
             <targetReference>Get_All_Opportunity_SKUs</targetReference>
@@ -5930,7 +6133,7 @@
     <decisions>
         <name>Opportunity_SKUs_Found</name>
         <label>Opportunity SKUs Found?</label>
-        <locationX>5692</locationX>
+        <locationX>6272</locationX>
         <locationY>5504</locationY>
         <defaultConnector>
             <targetReference>Get_Main_Products_0</targetReference>
@@ -5955,7 +6158,7 @@
     <decisions>
         <name>Opportunity_SKUs_Found_2</name>
         <label>Opportunity SKUs Found</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>21764</locationY>
         <defaultConnector>
             <targetReference>Create_Opportunity_Promos_Loop</targetReference>
@@ -6005,7 +6208,7 @@
     <decisions>
         <name>Other_Main_Products_Found</name>
         <label>Other Main Products Found?</label>
-        <locationX>13974</locationX>
+        <locationX>15134</locationX>
         <locationY>5936</locationY>
         <defaultConnector>
             <targetReference>No_Other_Products_Found_Screen</targetReference>
@@ -6030,7 +6233,7 @@
     <decisions>
         <name>Product_Match_Brand</name>
         <label>Product Match Brand?</label>
-        <locationX>8277</locationX>
+        <locationX>8857</locationX>
         <locationY>19412</locationY>
         <defaultConnector>
             <targetReference>Product_Loop</targetReference>
@@ -6062,7 +6265,7 @@
     <decisions>
         <name>Product_Sku_Promotions_Found</name>
         <label>Product Sku Promotions Found?</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>7352</locationY>
         <defaultConnector>
             <targetReference>Short_Term_Discount_Type2</targetReference>
@@ -6087,8 +6290,8 @@
     <decisions>
         <name>Products_Edited</name>
         <label>Products Edited?</label>
-        <locationX>7266</locationX>
-        <locationY>9368</locationY>
+        <locationX>8360</locationX>
+        <locationY>9884</locationY>
         <defaultConnector>
             <targetReference>Products_Selected</targetReference>
         </defaultConnector>
@@ -6112,8 +6315,8 @@
     <decisions>
         <name>Products_Selected</name>
         <label>Products Selected?</label>
-        <locationX>7266</locationX>
-        <locationY>10526</locationY>
+        <locationX>8490</locationX>
+        <locationY>9992</locationY>
         <defaultConnector>
             <targetReference>Get_Required_SKU_Product_Records</targetReference>
         </defaultConnector>
@@ -6137,7 +6340,7 @@
     <decisions>
         <name>Promotion_Match</name>
         <label>Promotion Match?</label>
-        <locationX>8365</locationX>
+        <locationX>8945</locationX>
         <locationY>19736</locationY>
         <defaultConnector>
             <targetReference>Find_Promotion_Loop</targetReference>
@@ -6234,8 +6437,8 @@
     <decisions>
         <name>Required_Products_Found</name>
         <label>Required Products Found?</label>
-        <locationX>7266</locationX>
-        <locationY>11342</locationY>
+        <locationX>8360</locationX>
+        <locationY>12134</locationY>
         <defaultConnector>
             <targetReference>Get_Add_Ons_and_Services_for_Main_Product</targetReference>
         </defaultConnector>
@@ -6259,7 +6462,7 @@
     <decisions>
         <name>Short_Term_Discount_Type2</name>
         <label>Short-Term Discount Type</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>7844</locationY>
         <defaultConnector>
             <targetReference>Sales_Approved_Promo_Selected</targetReference>
@@ -6306,7 +6509,7 @@
     <decisions>
         <name>Short_Term_or_Lifetime</name>
         <label>Short-Term or Lifetime</label>
-        <locationX>13974</locationX>
+        <locationX>15134</locationX>
         <locationY>13400</locationY>
         <defaultConnector>
             <targetReference>dec_Is_Lifetime_Promo_Already_Added</targetReference>
@@ -6396,7 +6599,7 @@
     <decisions>
         <name>Short_Term_Promo_Type</name>
         <label>Short-Term Promo Type</label>
-        <locationX>11862</locationX>
+        <locationX>13022</locationX>
         <locationY>11852</locationY>
         <defaultConnector>
             <targetReference>Selected_Promos_Loop</targetReference>
@@ -6461,7 +6664,7 @@
     <decisions>
         <name>Short_Term_Promotions_Found</name>
         <label>Short Term Promotions Found?</label>
-        <locationX>11521</locationX>
+        <locationX>12681</locationX>
         <locationY>6836</locationY>
         <defaultConnector>
             <isGoTo>true</isGoTo>
@@ -6487,7 +6690,7 @@
     <decisions>
         <name>Single_Brand_Promotion_Match</name>
         <label>Single Brand Promotion Match?</label>
-        <locationX>8805</locationX>
+        <locationX>9385</locationX>
         <locationY>17000</locationY>
         <defaultConnector>
             <targetReference>Single_Brand_Find_Promotion_Loop</targetReference>
@@ -6512,7 +6715,7 @@
     <decisions>
         <name>SKU_Product_and_Promotion_SKU_Product_Match</name>
         <label>SKU Product and Promotion SKU Product Match</label>
-        <locationX>14304</locationX>
+        <locationX>15464</locationX>
         <locationY>13292</locationY>
         <defaultConnector>
             <targetReference>SKU_Product_Promo_Match_Loop</targetReference>
@@ -6715,7 +6918,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Add_Non_Partnership_Lifetime_Product_Sku_Promos_to_Display_Collection</name>
         <label>Add Non-Partnership Lifetime Product Sku Promos to Display Collection</label>
-        <locationX>9870</locationX>
+        <locationX>11030</locationX>
         <locationY>10868</locationY>
         <collectionReference>Get_Non_Parntership_Lifetime_Product_Sku_Promos</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6729,8 +6932,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Add_Selected_Add_On_and_Service_Ids_to_Selected_Product_Id_Collection</name>
         <label>Add Selected Add On and Service Ids to Selected Product Id Collection</label>
-        <locationX>4626</locationX>
-        <locationY>9752</locationY>
+        <locationX>5282</locationX>
+        <locationY>9284</locationY>
         <collectionReference>collSelectedProducts</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
@@ -6743,7 +6946,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Apply_Bundle_Attributes_Loop</name>
         <label>Apply Bundle Attributes Loop</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>20672</locationY>
         <collectionReference>collOpportunitySKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6757,7 +6960,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Apply_Bundle_Attributes_Sub_Loop</name>
         <label>Apply Bundle Attributes Sub-Loop</label>
-        <locationX>7661</locationX>
+        <locationX>8241</locationX>
         <locationY>20780</locationY>
         <collectionReference>Get_Bundle_SKU_Products</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6771,7 +6974,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Assign_Main_Product_Loop</name>
         <label>Assign Main Product Loop</label>
-        <locationX>5628</locationX>
+        <locationX>6208</locationX>
         <locationY>5612</locationY>
         <collectionReference>Get_Existing_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6785,7 +6988,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Brand_Count_Loop</name>
         <label>Brand Count Loop</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>15452</locationY>
         <collectionReference>collAggregateSelectedProducts</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6799,7 +7002,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Brand_Loop</name>
         <label>Brand Loop</label>
-        <locationX>6561</locationX>
+        <locationX>7141</locationX>
         <locationY>17300</locationY>
         <collectionReference>varSelectedBrands</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6813,7 +7016,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Build_All_Opp_SKU_Id_Loop</name>
         <label>Build All Opp SKU Id Loop</label>
-        <locationX>10253</locationX>
+        <locationX>11413</locationX>
         <locationY>5396</locationY>
         <collectionReference>Get_All_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6827,8 +7030,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Build_Required_SKU_Product_Id_Collection_Loop</name>
         <label>Build Required SKU Product Id Collection Loop</label>
-        <locationX>7266</locationX>
-        <locationY>10934</locationY>
+        <locationX>8360</locationX>
+        <locationY>11726</locationY>
         <collectionReference>Get_Required_SKU_Product_Records</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
@@ -6855,8 +7058,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Check_for_Existing_Add_On_Loop</name>
         <label>Check for Existing Add On Loop</label>
-        <locationX>4758</locationX>
-        <locationY>10136</locationY>
+        <locationX>5240</locationX>
+        <locationY>10628</locationY>
         <collectionReference>Get_All_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
@@ -6869,22 +7072,22 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Check_for_Quantity_Lock_on_Edited_Addon_Loop</name>
         <label>Check for Quantity Lock on Edited Addon Loop</label>
-        <locationX>4626</locationX>
-        <locationY>8552</locationY>
+        <locationX>5066</locationX>
+        <locationY>9068</locationY>
         <collectionReference>dtAddOnsAndServices.outputEditedRows</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
             <targetReference>dec_Is_Edited_Addon_Quantity_Locked</targetReference>
         </nextValueConnector>
         <noMoreValuesConnector>
-            <targetReference>Add_Edited_Addon_to_Collection</targetReference>
+            <targetReference>Selected_Addons_Loop</targetReference>
         </noMoreValuesConnector>
     </loops>
     <loops>
         <name>Check_if_Opportunity_Already_Has_Brand_Loop</name>
         <label>Check if Opportunity Already Has Brand Loop</label>
-        <locationX>6386</locationX>
-        <locationY>8768</locationY>
+        <locationX>7042</locationX>
+        <locationY>9284</locationY>
         <collectionReference>Get_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
@@ -6897,7 +7100,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Contract_SKUs_Assignment_Loop_0</name>
         <label>Contract SKUs Assignment Loop</label>
-        <locationX>7157</locationX>
+        <locationX>7737</locationX>
         <locationY>4220</locationY>
         <collectionReference>Get_Contract_Line_Items_0</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6911,7 +7114,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Create_Already_Picked_Products_Collection_Loop</name>
         <label>Create Already Picked Products Collection Loop</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>2888</locationY>
         <collectionReference>Get_All_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6925,7 +7128,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Create_Opportunity_Promos_Loop</name>
         <label>Create Opportunity Promos Loop</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>22472</locationY>
         <collectionReference>collOpportunitySKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6939,7 +7142,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Create_Promotion_Id_Loop</name>
         <label>Create Promotion Id Loop</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>6944</locationY>
         <collectionReference>Get_Short_Term_Promotions</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -6953,49 +7156,49 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Edited_Addons_Loop</name>
         <label>Edited Addons Loop</label>
-        <locationX>4626</locationX>
-        <locationY>9152</locationY>
+        <locationX>5506</locationX>
+        <locationY>9668</locationY>
         <collectionReference>dtAddOnsAndServices.outputEditedRows</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
-            <targetReference>Add_Edited_Addon_Id_to_Collection</targetReference>
+            <targetReference>dec_Does_Edited_Product_Match_Selected_Product</targetReference>
         </nextValueConnector>
         <noMoreValuesConnector>
-            <targetReference>Is_Addon_Selected</targetReference>
+            <targetReference>dec_Was_Selected_Product_Edited</targetReference>
         </noMoreValuesConnector>
     </loops>
     <loops>
         <name>Edited_Main_Product_Quantity_Locked_Loop</name>
         <label>Edited Main Product Quantity Locked Loop</label>
-        <locationX>7134</locationX>
-        <locationY>9476</locationY>
+        <locationX>8230</locationX>
+        <locationY>9992</locationY>
         <collectionReference>dtMainProducts.outputEditedRows</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
             <targetReference>dec_Main_Product_Quantity_is_Locked</targetReference>
         </nextValueConnector>
         <noMoreValuesConnector>
-            <targetReference>Add_Edited_Main_Product_to_Selected_Products_Collection</targetReference>
+            <targetReference>Selected_Main_Products_Loop</targetReference>
         </noMoreValuesConnector>
     </loops>
     <loops>
         <name>Edited_Main_Products_Loop</name>
         <label>Edited Main Products Loop</label>
-        <locationX>7134</locationX>
-        <locationY>10142</locationY>
+        <locationX>8670</locationX>
+        <locationY>10658</locationY>
         <collectionReference>dtMainProducts.outputEditedRows</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
-            <targetReference>Assign_Edited_Product_Ids_to_Collections</targetReference>
+            <targetReference>dec_Does_Selected_Main_Product_Match_Edited_Main_Product</targetReference>
         </nextValueConnector>
         <noMoreValuesConnector>
-            <targetReference>Products_Selected</targetReference>
+            <targetReference>dec_Was_Selected_Main_Product_Added_to_Collection</targetReference>
         </noMoreValuesConnector>
     </loops>
     <loops>
         <name>Existing_Opportunity_Promo_Id_Loop</name>
         <label>Existing Opportunity Promo Id Loop</label>
-        <locationX>12232</locationX>
+        <locationX>13392</locationX>
         <locationY>6236</locationY>
         <collectionReference>Get_Existing_Opportunity_Promos</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7023,7 +7226,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Find_Promotion_Loop</name>
         <label>Find Promotion Loop</label>
-        <locationX>8145</locationX>
+        <locationX>8725</locationX>
         <locationY>19628</locationY>
         <collectionReference>collAggregatePromotions</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7037,7 +7240,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Get_Bundle_Ids_Loop</name>
         <label>Get Bundle Ids Loop</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>1880</locationY>
         <collectionReference>Get_Bundled_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7051,7 +7254,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Lifetime_Partnership_Promos_Loop</name>
         <label>Lifetime Partnership Promos Loop</label>
-        <locationX>9569</locationX>
+        <locationX>10729</locationX>
         <locationY>9500</locationY>
         <collectionReference>Get_All_Related_Lifetime_Promotions</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7065,7 +7268,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Lifetime_Promotion_Id_Loop</name>
         <label>Lifetime Promotion Id Loop</label>
-        <locationX>9677</locationX>
+        <locationX>10837</locationX>
         <locationY>8984</locationY>
         <collectionReference>Get_Lifetime_Promotions</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7079,7 +7282,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Non_Parntership_Lifetime_Promos_Loop</name>
         <label>Non-Parntership Lifetime Promos Loop</label>
-        <locationX>9870</locationX>
+        <locationX>11030</locationX>
         <locationY>10268</locationY>
         <collectionReference>Get_All_Non_Partnership_Lifetime_Promotions</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7093,7 +7296,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Open_Opportunity_Loop</name>
         <label>Open Opportunity Loop</label>
-        <locationX>7245</locationX>
+        <locationX>7825</locationX>
         <locationY>1064</locationY>
         <collectionReference>collOpportunities</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7107,7 +7310,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Open_Opportunity_SKU_Loop</name>
         <label>Open Opportunity SKU Loop</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>16052</locationY>
         <collectionReference>Get_Open_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7135,7 +7338,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Opportunity_Promos_Loop</name>
         <label>Opportunity Promos Loop</label>
-        <locationX>7793</locationX>
+        <locationX>8373</locationX>
         <locationY>22580</locationY>
         <collectionReference>collOpportunityPromo</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7149,7 +7352,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Partnership_Discounts_Loop</name>
         <label>Partnership Discounts Loop</label>
-        <locationX>9677</locationX>
+        <locationX>10837</locationX>
         <locationY>8576</locationY>
         <collectionReference>Get_Partnership_Discounts</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7163,7 +7366,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Product_Loop</name>
         <label>Product Loop</label>
-        <locationX>7705</locationX>
+        <locationX>8285</locationX>
         <locationY>19196</locationY>
         <collectionReference>collAggregateSelectedProducts</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7205,8 +7408,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Required_Products_Loop</name>
         <label>Required Products Loop</label>
-        <locationX>7246</locationX>
-        <locationY>11666</locationY>
+        <locationX>8340</locationX>
+        <locationY>12458</locationY>
         <collectionReference>Get_Required_SKU_Products</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
@@ -7214,6 +7417,34 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
         </nextValueConnector>
         <noMoreValuesConnector>
             <targetReference>Get_Add_Ons_and_Services_for_Main_Product</targetReference>
+        </noMoreValuesConnector>
+    </loops>
+    <loops>
+        <name>Selected_Addons_Loop</name>
+        <label>Selected Addons Loop</label>
+        <locationX>5066</locationX>
+        <locationY>9560</locationY>
+        <collectionReference>dtAddOnsAndServices.outputSelectedRows</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>Edited_Addons_Loop</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>Check_for_Existing_Add_On_Loop</targetReference>
+        </noMoreValuesConnector>
+    </loops>
+    <loops>
+        <name>Selected_Main_Products_Loop</name>
+        <label>Selected Main Products Loop</label>
+        <locationX>8230</locationX>
+        <locationY>10550</locationY>
+        <collectionReference>dtMainProducts.outputSelectedRows</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>Edited_Main_Products_Loop</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>Get_Required_SKU_Product_Records</targetReference>
         </noMoreValuesConnector>
     </loops>
     <loops>
@@ -7233,7 +7464,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Selected_Promos_Loop</name>
         <label>Selected Promos Loop</label>
-        <locationX>11862</locationX>
+        <locationX>13022</locationX>
         <locationY>12518</locationY>
         <collectionReference>collSelectedPromotionSkus</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7247,7 +7478,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Set_Contract_Id_Collection_0</name>
         <label>Set Contract Id Collection</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>3704</locationY>
         <collectionReference>Get_Contract_Subscriptions_0</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7261,8 +7492,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Set_Quantity_on_Filtered_Products_Loop</name>
         <label>Set Quantity on Filtered Products Loop</label>
-        <locationX>6386</locationX>
-        <locationY>10076</locationY>
+        <locationX>7042</locationX>
+        <locationY>10592</locationY>
         <collectionReference>collFilteredMainProducts</collectionReference>
         <iterationOrder>Asc</iterationOrder>
         <nextValueConnector>
@@ -7275,7 +7506,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Short_Term_Promot</name>
         <label>Short Term Promotion Loop</label>
-        <locationX>10038</locationX>
+        <locationX>11198</locationX>
         <locationY>7460</locationY>
         <collectionReference>Get_All_Related_Short_Term_Promotions</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7289,7 +7520,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Single_Brand_Find_Promotion_Loop</name>
         <label>Single Brand Find Promotion Loop</label>
-        <locationX>8585</locationX>
+        <locationX>9165</locationX>
         <locationY>16892</locationY>
         <collectionReference>collAggregatePromotions</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7303,7 +7534,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>Single_Brand_Product_Loop</name>
         <label>Single Brand Product Loop</label>
-        <locationX>8145</locationX>
+        <locationX>8725</locationX>
         <locationY>16568</locationY>
         <collectionReference>collAggregateSelectedProducts</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7317,7 +7548,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <loops>
         <name>SKU_Product_Promo_Match_Loop</name>
         <label>SKU Product Promo Match Loop</label>
-        <locationX>13490</locationX>
+        <locationX>14650</locationX>
         <locationY>13184</locationY>
         <collectionReference>Get_All_Opportunity_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7357,9 +7588,23 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
         </noMoreValuesConnector>
     </loops>
     <loops>
+        <name>Update_Add_On_Quantity_Loop</name>
+        <label>Update Add On Quantity Loop</label>
+        <locationX>6277</locationX>
+        <locationY>7844</locationY>
+        <collectionReference>collDisplayProducts</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>Set_Quantity_to_1</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>Set_Display_Collection</targetReference>
+        </noMoreValuesConnector>
+    </loops>
+    <loops>
         <name>Update_Opportunity_SKUs_to_Parent_Loop</name>
         <label>Update Opportunity SKUs to Parent Loop</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>21872</locationY>
         <collectionReference>Get_This_Opportunity_s_SKUs</collectionReference>
         <iterationOrder>Asc</iterationOrder>
@@ -7392,7 +7637,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordCreates>
         <name>Create_Brand_Opportuntiy</name>
         <label>Create Brand Opportuntiy</label>
-        <locationX>7507</locationX>
+        <locationX>8087</locationX>
         <locationY>18722</locationY>
         <assignRecordIdToReference>varNewOpportunityId</assignRecordIdToReference>
         <connector>
@@ -7574,7 +7819,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordCreates>
         <name>Create_Opportunity_Promos</name>
         <label>Create Opportunity Promos</label>
-        <locationX>7089</locationX>
+        <locationX>7669</locationX>
         <locationY>23372</locationY>
         <connector>
             <targetReference>Navigate_to_New_Parent_Opportunity</targetReference>
@@ -7587,7 +7832,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordCreates>
         <name>Create_Opportunity_Promos2</name>
         <label>Create Opportunity Promos</label>
-        <locationX>11862</locationX>
+        <locationX>13022</locationX>
         <locationY>14468</locationY>
         <faultConnector>
             <targetReference>Assign_Create_Opportunity_Promos_to_faultObject2</targetReference>
@@ -7597,7 +7842,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordCreates>
         <name>Create_Opportunity_SKU_Records</name>
         <label>Create Opportunity SKU Records</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>21548</locationY>
         <connector>
             <targetReference>Get_This_Opportunity_s_SKUs</targetReference>
@@ -7610,7 +7855,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordCreates>
         <name>Create_Parent_Opportunity</name>
         <label>Create Parent Opportunity</label>
-        <locationX>6825</locationX>
+        <locationX>7405</locationX>
         <locationY>16892</locationY>
         <connector>
             <targetReference>Update_This_Opportunity</targetReference>
@@ -7654,8 +7899,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordDeletes>
         <name>Delete_Opportunity_SKUs3</name>
         <label>Delete Opportunity SKUs</label>
-        <locationX>6980</locationX>
-        <locationY>8984</locationY>
+        <locationX>8074</locationX>
+        <locationY>9500</locationY>
         <connector>
             <targetReference>Set_Variables</targetReference>
         </connector>
@@ -7685,7 +7930,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Add_On_Products</name>
         <label>Get Add-On Products</label>
-        <locationX>5697</locationX>
+        <locationX>6277</locationX>
         <locationY>6728</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -7748,8 +7993,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Add_Ons_and_Services_for_Main_Product</name>
         <label>Get Add Ons and Services for Main Product</label>
-        <locationX>7266</locationX>
-        <locationY>12134</locationY>
+        <locationX>8360</locationX>
+        <locationY>12926</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Has_Add_Ons</targetReference>
@@ -7867,7 +8112,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_All_Non_Partnership_Lifetime_Promotions</name>
         <label>Get All Non Partnership Lifetime Promotions</label>
-        <locationX>9978</locationX>
+        <locationX>11138</locationX>
         <locationY>10052</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -7902,7 +8147,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_All_Opportunity_SKUs</name>
         <label>Get All Opportunity SKUs</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>2780</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8047,7 +8292,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_All_Related_Lifetime_Promotions</name>
         <label>Get All Related Lifetime Promotions</label>
-        <locationX>9677</locationX>
+        <locationX>10837</locationX>
         <locationY>9284</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8082,7 +8327,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_All_Related_Short_Term_Promotions</name>
         <label>Get All Related Short-Term Promotions</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>7244</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8153,7 +8398,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
         <description>Get bundled Opportunity SKUs related to Opportunity.</description>
         <name>Get_Bundled_Opportunity_SKUs</name>
         <label>Get Bundled Opportunity SKUs</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>1556</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8249,7 +8494,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Contract_Line_Items_0</name>
         <label>Get Contract Line Items</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>4004</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8270,7 +8515,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Contract_SKU</name>
         <label>Get Contract SKU</label>
-        <locationX>13820</locationX>
+        <locationX>14980</locationX>
         <locationY>6152</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8298,7 +8543,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Contract_Subscriptions_0</name>
         <label>Get Contract Subscriptions</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>3488</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8326,7 +8571,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Existing_Opportunity_Promos</name>
         <label>Get Existing Opportunity Promos</label>
-        <locationX>12340</locationX>
+        <locationX>13500</locationX>
         <locationY>6020</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8361,7 +8606,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Existing_Opportunity_SKUs</name>
         <label>Get Existing Opportunity SKUs</label>
-        <locationX>5692</locationX>
+        <locationX>6272</locationX>
         <locationY>5396</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8389,7 +8634,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Grandfathered_Add_On_Products</name>
         <label>Get Grandfathered Add-On Products</label>
-        <locationX>5543</locationX>
+        <locationX>6123</locationX>
         <locationY>7352</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8459,8 +8704,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Grandfathered_Main_Products</name>
         <label>Get Grandfathered Main Products</label>
-        <locationX>6232</locationX>
-        <locationY>9584</locationY>
+        <locationX>6888</locationX>
+        <locationY>10100</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Grandfathered_Products_Found</targetReference>
@@ -8494,7 +8739,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Lifetime_Promotions</name>
         <label>Get Lifetime Promotions</label>
-        <locationX>9677</locationX>
+        <locationX>10837</locationX>
         <locationY>8876</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8536,7 +8781,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Main_Products</name>
         <label>Get Main Products</label>
-        <locationX>14183</locationX>
+        <locationX>15343</locationX>
         <locationY>5504</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8557,7 +8802,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Main_Products_0</name>
         <label>Get Main Products</label>
-        <locationX>5692</locationX>
+        <locationX>6272</locationX>
         <locationY>6188</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8578,7 +8823,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Non_Parntership_Lifetime_Product_Sku_Promos</name>
         <label>Get Non-Parntership Lifetime Product Sku Promos</label>
-        <locationX>9978</locationX>
+        <locationX>11138</locationX>
         <locationY>10652</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8606,7 +8851,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Open_Child_Opportunities</name>
         <label>Get Open Child Opportunities</label>
-        <locationX>7089</locationX>
+        <locationX>7669</locationX>
         <locationY>566</locationY>
         <assignNullValuesIfNoRecordsFound>true</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8651,7 +8896,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Open_Child_Opportunity</name>
         <label>Get Open Child Opportunity</label>
-        <locationX>7375</locationX>
+        <locationX>7955</locationX>
         <locationY>18398</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8707,7 +8952,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Open_Opportunities</name>
         <label>Get Open Opportunities</label>
-        <locationX>7375</locationX>
+        <locationX>7955</locationX>
         <locationY>17624</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8763,7 +9008,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Open_Opportunity_SKUs</name>
         <label>Get Open Opportunity SKUs</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>15944</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8805,7 +9050,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity</name>
         <label>Get Opportunity</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>15344</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8826,7 +9071,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity_Bundles</name>
         <label>Get Opportunity Bundles</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>2180</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8847,7 +9092,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity_Promos</name>
         <label>Get Opportunity Promos</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>1664</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8907,7 +9152,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity_Record_Types</name>
         <label>Get Opportunity Record Types</label>
-        <locationX>7507</locationX>
+        <locationX>8087</locationX>
         <locationY>18614</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8935,7 +9180,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity_SKU_Standard_Record_Type</name>
         <label>Get Opportunity SKU Standard Record Type</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>16352</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -8963,7 +9208,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity_SKUs</name>
         <label>Get Opportunity SKUs</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>1448</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9029,8 +9274,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity_SKUs_to_Delete</name>
         <label>Get Opportunity SKUs to Delete</label>
-        <locationX>7112</locationX>
-        <locationY>8768</locationY>
+        <locationX>8206</locationX>
+        <locationY>9284</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>dec_Opportunity_SKUs_to_Delete_Found</targetReference>
@@ -9078,7 +9323,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Opportunity_SKUs_with_Unlocked_Quantities</name>
         <label>Get Opportunity SKUs with Unlocked Quantities</label>
-        <locationX>13424</locationX>
+        <locationX>14584</locationX>
         <locationY>5396</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9120,7 +9365,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Other_Main_Products</name>
         <label>Get Other Main Products</label>
-        <locationX>13974</locationX>
+        <locationX>15134</locationX>
         <locationY>5828</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9162,7 +9407,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Parent_Opportunity_Record_Type</name>
         <label>Get Parent Opportunity Record Type</label>
-        <locationX>6825</locationX>
+        <locationX>7405</locationX>
         <locationY>16676</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9183,7 +9428,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Partnership_Discounts</name>
         <label>Get Partnership Discounts</label>
-        <locationX>9819</locationX>
+        <locationX>10979</locationX>
         <locationY>8360</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9225,8 +9470,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Required_SKU_Product_Records</name>
         <label>Get Required SKU Product Records</label>
-        <locationX>7266</locationX>
-        <locationY>10826</locationY>
+        <locationX>8360</locationX>
+        <locationY>11618</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Build_Required_SKU_Product_Id_Collection_Loop</targetReference>
@@ -9246,8 +9491,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Required_SKU_Products</name>
         <label>Get Required SKU Products</label>
-        <locationX>7266</locationX>
-        <locationY>11234</locationY>
+        <locationX>8360</locationX>
+        <locationY>12026</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Required_Products_Found</targetReference>
@@ -9267,7 +9512,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_Short_Term_Promotions</name>
         <label>Get Short-Term Promotions</label>
-        <locationX>11521</locationX>
+        <locationX>12681</locationX>
         <locationY>6728</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9323,7 +9568,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_This_Opportunity</name>
         <label>Get This Opportunity</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>134</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9347,7 +9592,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordLookups>
         <name>Get_This_Opportunity_s_SKUs</name>
         <label>Get This Opportunity&#39;s SKUs</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>21656</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
@@ -9389,7 +9634,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordUpdates>
         <name>Update_Lifetime_Opportunity_Skus</name>
         <label>Update Lifetime Opportunity Skus</label>
-        <locationX>11862</locationX>
+        <locationX>13022</locationX>
         <locationY>14360</locationY>
         <connector>
             <targetReference>Create_Opportunity_Promos2</targetReference>
@@ -9412,7 +9657,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordUpdates>
         <name>Update_Opportunity_SKU_Quantities</name>
         <label>Update Opportunity SKU Quantities</label>
-        <locationX>13424</locationX>
+        <locationX>14584</locationX>
         <locationY>5612</locationY>
         <connector>
             <targetReference>Get_Opportunity</targetReference>
@@ -9435,7 +9680,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordUpdates>
         <name>Update_Opportunity_SKUs_2</name>
         <label>Update Opportunity SKUs</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>22280</locationY>
         <connector>
             <targetReference>Create_Opportunity_Promos_Loop</targetReference>
@@ -9445,7 +9690,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordUpdates>
         <name>Update_Opportunity_SKUs_with_Promo_Details</name>
         <label>Update Opportunity SKUs with Promo Details</label>
-        <locationX>11862</locationX>
+        <locationX>13022</locationX>
         <locationY>14252</locationY>
         <connector>
             <targetReference>Update_Lifetime_Opportunity_Skus</targetReference>
@@ -9468,7 +9713,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <recordUpdates>
         <name>Update_This_Opportunity</name>
         <label>Update This Opportunity</label>
-        <locationX>6825</locationX>
+        <locationX>7405</locationX>
         <locationY>17000</locationY>
         <connector>
             <targetReference>Set_Parent_Opportunity_Id_Variable_2</targetReference>
@@ -9493,8 +9738,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Add_Ons_and_Services</name>
         <label>Add Ons and Services</label>
-        <locationX>5692</locationX>
-        <locationY>8120</locationY>
+        <locationX>6272</locationX>
+        <locationY>8636</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -9905,8 +10150,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Brand_Selection</name>
         <label>Brand Selection</label>
-        <locationX>5726</locationX>
-        <locationY>8552</locationY>
+        <locationX>6382</locationX>
+        <locationY>9068</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -9930,6 +10175,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
                     <dataType>String</dataType>
                     <fieldText>Brand</fieldText>
                     <fieldType>RadioButtons</fieldType>
+                    <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
                     <isRequired>false</isRequired>
                 </fields>
                 <fields>
@@ -10082,7 +10328,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Copy_1_of_No_Other_Products_Found_Screen</name>
         <label>Change Tier Screen</label>
-        <locationX>13820</locationX>
+        <locationX>14980</locationX>
         <locationY>6044</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -10248,7 +10494,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Fault_Screen</name>
         <label>Fault Screen</label>
-        <locationX>12368</locationX>
+        <locationX>13528</locationX>
         <locationY>14684</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
@@ -10264,7 +10510,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Lifetime_Promo_Already_Exists_Screen</name>
         <label>Lifetime Promo Already Exists Screen</label>
-        <locationX>14106</locationX>
+        <locationX>15266</locationX>
         <locationY>13616</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -10341,6 +10587,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
             <dataType>String</dataType>
             <fieldText>Loss Reason</fieldText>
             <fieldType>DropdownBox</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
         </fields>
         <fields>
@@ -10349,6 +10596,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
             <dataType>String</dataType>
             <fieldText>Lost Due to Feature</fieldText>
             <fieldType>MultiSelectPicklist</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
             <visibilityRule>
                 <conditionLogic>and</conditionLogic>
@@ -10367,12 +10615,14 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
             <dataType>String</dataType>
             <fieldText>Lost To</fieldText>
             <fieldType>DropdownBox</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
         </fields>
         <fields>
             <name>Explanation</name>
             <fieldText>Explanation</fieldText>
             <fieldType>LargeTextArea</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
         </fields>
         <fields>
@@ -10419,8 +10669,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Main_Product_Selection</name>
         <label>Main Product Selection</label>
-        <locationX>6589</locationX>
-        <locationY>8336</locationY>
+        <locationX>7480</locationX>
+        <locationY>8852</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -10602,6 +10852,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
             <dataType>Boolean</dataType>
             <fieldText>I confirm I want to remove the current SKU and any add-ons.</fieldText>
             <fieldType>InputField</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
             <validationRule>
                 <errorMessage>&lt;p&gt;&lt;em style=&quot;color: rgb(255, 0, 0);&quot;&gt;You must check this box to proceed.&lt;/em&gt;&lt;/p&gt;</errorMessage>
@@ -10662,7 +10913,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Main_Product_Selection_for_Add_On_Screen</name>
         <label>Main Product Selection for Add-On Screen</label>
-        <locationX>5290</locationX>
+        <locationX>5870</locationX>
         <locationY>6404</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -10818,7 +11069,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Main_Product_Selection_Screen</name>
         <label>Main Product Selection Screen</label>
-        <locationX>13974</locationX>
+        <locationX>15134</locationX>
         <locationY>5720</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -10921,8 +11172,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>No_Main_Products_Found_Screen</name>
         <label>No Main Products Found Screen</label>
-        <locationX>6518</locationX>
-        <locationY>10700</locationY>
+        <locationX>7174</locationX>
+        <locationY>11216</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -10984,7 +11235,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>No_Other_Products_Found_Screen</name>
         <label>No Other Products Found Screen</label>
-        <locationX>14128</locationX>
+        <locationX>15288</locationX>
         <locationY>6044</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -11000,7 +11251,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>No_Products_to_Upgrade_Screen</name>
         <label>No Products to Upgrade Screen</label>
-        <locationX>14392</locationX>
+        <locationX>15552</locationX>
         <locationY>5720</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
@@ -11021,7 +11272,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Open_Opportunities_Screen</name>
         <label>Open Opportunities Screen</label>
-        <locationX>7221</locationX>
+        <locationX>7801</locationX>
         <locationY>17840</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -11100,7 +11351,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Product_Selection</name>
         <label>Product Selection</label>
-        <locationX>7353</locationX>
+        <locationX>7933</locationX>
         <locationY>5180</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -11632,8 +11883,8 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Required_Products_Screen</name>
         <label>Required Products Screen</label>
-        <locationX>7070</locationX>
-        <locationY>11450</locationY>
+        <locationX>8164</locationX>
+        <locationY>12242</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -11791,7 +12042,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Screen_Edit_Quantity</name>
         <label>Screen Edit Quantity</label>
-        <locationX>13424</locationX>
+        <locationX>14584</locationX>
         <locationY>5504</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -12194,7 +12445,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Select_Discount_Type_Screen</name>
         <label>Select Discount Type Screen</label>
-        <locationX>10253</locationX>
+        <locationX>11413</locationX>
         <locationY>5804</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -12220,6 +12471,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
                     <dataType>String</dataType>
                     <fieldText>Discount Type</fieldText>
                     <fieldType>MultiSelectCheckboxes</fieldType>
+                    <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
                     <isRequired>true</isRequired>
                 </fields>
                 <inputParameters>
@@ -12239,6 +12491,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
                     <dataType>String</dataType>
                     <fieldText>Short-Term Discount Type</fieldText>
                     <fieldType>RadioButtons</fieldType>
+                    <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
                     <isRequired>false</isRequired>
                     <visibilityRule>
                         <conditionLogic>and</conditionLogic>
@@ -12328,7 +12581,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Select_Promotion_Screen</name>
         <label>Select Promotion Screen</label>
-        <locationX>10146</locationX>
+        <locationX>11306</locationX>
         <locationY>11336</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -12928,7 +13181,7 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     <screens>
         <name>Short_Term_Promo_Already_Exists_Screen</name>
         <label>Short Term Promo Already Exists Screen</label>
-        <locationX>13578</locationX>
+        <locationX>14738</locationX>
         <locationY>13616</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
@@ -12984,13 +13237,21 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
         <showHeader>false</showHeader>
     </screens>
     <start>
-        <locationX>7227</locationX>
+        <locationX>7807</locationX>
         <locationY>0</locationY>
         <connector>
             <targetReference>Get_This_Opportunity</targetReference>
         </connector>
     </start>
-    <status>Active</status>
+    <status>Draft</status>
+    <variables>
+        <name>coll_Addons_With_Quantity</name>
+        <dataType>SObject</dataType>
+        <isCollection>true</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>SKU_Product__c</objectType>
+    </variables>
     <variables>
         <name>coll_Picked_Sku_Product_Ids</name>
         <dataType>String</dataType>
@@ -13548,6 +13809,16 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
         <isOutput>false</isOutput>
     </variables>
     <variables>
+        <name>var_Addon_Is_Edited</name>
+        <dataType>Boolean</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <booleanValue>false</booleanValue>
+        </value>
+    </variables>
+    <variables>
         <name>var_Company_Promo_Selected</name>
         <dataType>Boolean</dataType>
         <isCollection>false</isCollection>
@@ -13559,6 +13830,16 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
     </variables>
     <variables>
         <name>var_From_Main_Product_Path</name>
+        <dataType>Boolean</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <booleanValue>false</booleanValue>
+        </value>
+    </variables>
+    <variables>
+        <name>var_Main_Product_Is_Edited</name>
         <dataType>Boolean</dataType>
         <isCollection>false</isCollection>
         <isInput>false</isInput>
@@ -13606,6 +13887,14 @@ right( text( ( 1 + {!Get_This_Opportunity.Short_Term_ARR__c}- floor( {!Get_This_
         <value>
             <booleanValue>false</booleanValue>
         </value>
+    </variables>
+    <variables>
+        <name>var_Temp_Sku_Product</name>
+        <dataType>SObject</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>SKU_Product__c</objectType>
     </variables>
     <variables>
         <name>varAddOnCount</name>


### PR DESCRIPTION
When adding a product via product picker, and editing quantity of that product, it adds multiple lines in error. This fix fixes that error.