### PR TITLE
Remove-Marketing-Nuture-or-Disqualified-Reason-from-Contact-or-Lead

### DIFF
--- a/unpackaged/main/default/flows/Contact_Remove_Marketing_Nurture_or_Disqualified_Reason.flow-meta.xml
+++ b/unpackaged/main/default/flows/Contact_Remove_Marketing_Nurture_or_Disqualified_Reason.flow-meta.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <decisions>
+        <name>Previous_Status_of_Contact</name>
+        <label>Previous Status of Contact</label>
+        <locationX>314</locationX>
+        <locationY>323</locationY>
+        <defaultConnectorLabel>No Updates</defaultConnectorLabel>
+        <rules>
+            <name>Previous_Status_Marketing_Nurture</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record__Prior.Status__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Marketing Nurture</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Remove_Marketing_Nurture_Reason</targetReference>
+            </connector>
+            <label>Previous Status Marketing Nurture</label>
+        </rules>
+        <rules>
+            <name>Previous_Status_Disqualified</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record__Prior.Status__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Disqualified</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Remove_Disqualified_Reason</targetReference>
+            </connector>
+            <label>Previous Status Disqualified</label>
+        </rules>
+    </decisions>
+    <environments>Default</environments>
+    <interviewLabel>Contact: Remove Marketing Nurture or Disqualified Reason {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Contact: Remove Marketing Nurture or Disqualified Reason</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordUpdates>
+        <name>Remove_Disqualified_Reason</name>
+        <label>Remove Disqualified Reason</label>
+        <locationX>314</locationX>
+        <locationY>431</locationY>
+        <inputAssignments>
+            <field>Disqualified_Reason__c</field>
+            <value>
+                <stringValue></stringValue>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <recordUpdates>
+        <name>Remove_Marketing_Nurture_Reason</name>
+        <label>Remove Marketing Nurture Reason</label>
+        <locationX>50</locationX>
+        <locationY>431</locationY>
+        <inputAssignments>
+            <field>Nurture_Marketing_Reasons__c</field>
+            <value>
+                <stringValue></stringValue>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <start>
+        <locationX>188</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Previous_Status_of_Contact</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Status__c</field>
+            <operator>IsChanged</operator>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </filters>
+        <object>Contact</object>
+        <recordTriggerType>Update</recordTriggerType>
+        <triggerType>RecordAfterSave</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>

--- a/unpackaged/main/default/flows/Lead_Remove_Marketing_Nurture_or_Disqualified_Reason.flow-meta.xml
+++ b/unpackaged/main/default/flows/Lead_Remove_Marketing_Nurture_or_Disqualified_Reason.flow-meta.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <decisions>
+        <name>Previous_status_of_lead</name>
+        <label>Previous status of lead</label>
+        <locationX>314</locationX>
+        <locationY>323</locationY>
+        <defaultConnectorLabel>No Updates</defaultConnectorLabel>
+        <rules>
+            <name>Previous_Status_Marketing_Nurture</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record__Prior.Status</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Marketing Nurture</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Remove_Marketing_Nurture_Reason</targetReference>
+            </connector>
+            <label>Previous Status Marketing Nurture</label>
+        </rules>
+        <rules>
+            <name>Previous_Status_Disqualified</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record__Prior.Status</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Disqualified</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Remove_Disqualified_Reason</targetReference>
+            </connector>
+            <label>Previous Status Disqualified</label>
+        </rules>
+    </decisions>
+    <environments>Default</environments>
+    <interviewLabel>Lead: Remove Marketing Nurture or Disqualified Reason {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Lead: Remove Marketing Nurture or Disqualified Reason</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordUpdates>
+        <name>Remove_Disqualified_Reason</name>
+        <label>Remove Disqualified Reason</label>
+        <locationX>314</locationX>
+        <locationY>431</locationY>
+        <inputAssignments>
+            <field>Disqualified_Reason__c</field>
+            <value>
+                <stringValue></stringValue>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <recordUpdates>
+        <name>Remove_Marketing_Nurture_Reason</name>
+        <label>Remove Marketing Nurture Reason</label>
+        <locationX>50</locationX>
+        <locationY>431</locationY>
+        <inputAssignments>
+            <field>Nurture_Marketing_Reasons__c</field>
+            <value>
+                <stringValue></stringValue>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <start>
+        <locationX>188</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Previous_status_of_lead</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Status</field>
+            <operator>IsChanged</operator>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </filters>
+        <object>Lead</object>
+        <recordTriggerType>Update</recordTriggerType>
+        <triggerType>RecordAfterSave</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>


### PR DESCRIPTION
Remove Marketing Nurture Reason or Disqualified Reason when lead or contact is moved out of those statuses