### PR TITLE
Docketwise-Stripe-Subscription-ID-Field-Permission-Set-Permission-Set-Group

### DIFF
--- a/unpackaged/main/default/layouts/Contract_SKU_Transaction__c-Contract SKU History Layout.layout-meta.xml
+++ b/unpackaged/main/default/layouts/Contract_SKU_Transaction__c-Contract SKU History Layout.layout-meta.xml
@@ -26,6 +26,10 @@
                 <behavior>Readonly</behavior>
                 <field>Opportunity_Close_Date__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Docketwise_Stripe_Subscription_ID__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -125,9 +129,9 @@
         <detailHeading>false</detailHeading>
         <editHeading>true</editHeading>
         <label>Custom Links</label>
-        <layoutColumns/>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <platformActionList>

--- a/unpackaged/main/default/objects/Contract_SKU_Transaction__c/fields/Docketwise_Stripe_Subscription_ID__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Contract_SKU_Transaction__c/fields/Docketwise_Stripe_Subscription_ID__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Docketwise_Stripe_Subscription_ID__c</fullName>
+    <description>Used by Sales Ops to validate that a subscription contract was found for this Docketwise transaction</description>
+    <externalId>false</externalId>
+    <label>Docketwise Stripe Subscription ID</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/main/default/permissionsetgroups/Senior_Sales_Ops.permissionsetgroup-meta.xml
+++ b/unpackaged/main/default/permissionsetgroups/Senior_Sales_Ops.permissionsetgroup-meta.xml
@@ -6,6 +6,7 @@
     <permissionSets>Contract_Sku_Transactions_and_Contract_Skus_Delete</permissionSets>
     <permissionSets>Create_Onboarding_after_Opportunity_Is_Closed</permissionSets>
     <permissionSets>Create_Report_and_Dashboard_Folders</permissionSets>
+    <permissionSets>Docketwise_Stripe_Subscsription_ID_Read_Write_Access</permissionSets>
     <permissionSets>Edit_Closed_Won_Opportunities</permissionSets>
     <permissionSets>Edit_MQL_Fields</permissionSets>
     <permissionSets>Inbound_Requests_Readonly</permissionSets>

--- a/unpackaged/main/default/permissionsets/Docketwise_Stripe_Subscsription_ID_Read_Write_Access.permissionset-meta.xml
+++ b/unpackaged/main/default/permissionsets/Docketwise_Stripe_Subscsription_ID_Read_Write_Access.permissionset-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Gives user the ability to edit Docketwise Stripe Subscription ID on the Contract SKU Transaction record</description>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Docketwise Stripe Subscsription ID Read/Write Access</label>
+</PermissionSet>

--- a/unpackaged/main/default/profiles/Admin.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Admin.profile-meta.xml
@@ -7640,6 +7640,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Analytics Cloud Integration User.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Analytics Cloud Integration User.profile-meta.xml
@@ -3343,6 +3343,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Analytics Cloud Security User.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Analytics Cloud Security User.profile-meta.xml
@@ -3343,6 +3343,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/CPQ Integration User.profile-meta.xml
+++ b/unpackaged/main/default/profiles/CPQ Integration User.profile-meta.xml
@@ -3284,6 +3284,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/ContractManager.profile-meta.xml
+++ b/unpackaged/main/default/profiles/ContractManager.profile-meta.xml
@@ -3454,6 +3454,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/End User.profile-meta.xml
+++ b/unpackaged/main/default/profiles/End User.profile-meta.xml
@@ -3454,6 +3454,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Engineering.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Engineering.profile-meta.xml
@@ -3581,6 +3581,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Executive Sponsor.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Executive Sponsor.profile-meta.xml
@@ -3464,6 +3464,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Executive.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Executive.profile-meta.xml
@@ -3609,6 +3609,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Finance.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Finance.profile-meta.xml
@@ -3691,6 +3691,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Integration - 6sense.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - 6sense.profile-meta.xml
@@ -3533,6 +3533,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Alchemer.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Alchemer.profile-meta.xml
@@ -2608,6 +2608,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Bizible.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Bizible.profile-meta.xml
@@ -3113,6 +3113,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Gong.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Gong.profile-meta.xml
@@ -3113,6 +3113,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Google Adwords.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Google Adwords.profile-meta.xml
@@ -3113,6 +3113,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - GoogleAds.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - GoogleAds.profile-meta.xml
@@ -2278,6 +2278,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Highspot.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Highspot.profile-meta.xml
@@ -3273,6 +3273,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Intercom %28DW%29.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Intercom %28DW%29.profile-meta.xml
@@ -3153,6 +3153,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Intercom %28MC%29.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Intercom %28MC%29.profile-meta.xml
@@ -2898,6 +2898,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Intercom %28MyCase%29.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Intercom %28MyCase%29.profile-meta.xml
@@ -2898,6 +2898,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Intercom %28Soluno%29.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Intercom %28Soluno%29.profile-meta.xml
@@ -2898,6 +2898,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Marketo.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Marketo.profile-meta.xml
@@ -2288,6 +2288,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Metadata.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Metadata.profile-meta.xml
@@ -3589,6 +3589,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Integration - MyCase App.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - MyCase App.profile-meta.xml
@@ -3594,6 +3594,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - OKTA.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - OKTA.profile-meta.xml
@@ -3118,6 +3118,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Outreach.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Outreach.profile-meta.xml
@@ -5083,6 +5083,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - OwnBackup.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - OwnBackup.profile-meta.xml
@@ -7085,6 +7085,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Integration - Partner Stack.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Partner Stack.profile-meta.xml
@@ -3154,6 +3154,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - RingLead.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - RingLead.profile-meta.xml
@@ -5473,6 +5473,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Integration - Tableau.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Tableau.profile-meta.xml
@@ -3613,6 +3613,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Integration - Workato.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Workato.profile-meta.xml
@@ -6300,6 +6300,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Integration - Zapier.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Integration - Zapier.profile-meta.xml
@@ -3530,6 +3530,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Marketing or Affinity Partnership.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Marketing or Affinity Partnership.profile-meta.xml
@@ -3613,6 +3613,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Marketing.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Marketing.profile-meta.xml
@@ -3593,6 +3593,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/MarketingProfile.profile-meta.xml
+++ b/unpackaged/main/default/profiles/MarketingProfile.profile-meta.xml
@@ -3479,6 +3479,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Minimum Access - Salesforce.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Minimum Access - Salesforce.profile-meta.xml
@@ -2989,6 +2989,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/MyCase Service.profile-meta.xml
+++ b/unpackaged/main/default/profiles/MyCase Service.profile-meta.xml
@@ -3534,6 +3534,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Operations.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Operations.profile-meta.xml
@@ -4565,6 +4565,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Orion Data Migration Integration.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Orion Data Migration Integration.profile-meta.xml
@@ -7423,6 +7423,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Product.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Product.profile-meta.xml
@@ -3646,6 +3646,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Read Only.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Read Only.profile-meta.xml
@@ -3469,6 +3469,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Sales - Soluno.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Sales - Soluno.profile-meta.xml
@@ -3629,6 +3629,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Sales Insights Integration User.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Sales Insights Integration User.profile-meta.xml
@@ -3469,6 +3469,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Sales.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Sales.profile-meta.xml
@@ -3629,6 +3629,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Salesforce API Only System Integrations.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Salesforce API Only System Integrations.profile-meta.xml
@@ -3368,6 +3368,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Service - Soluno.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Service - Soluno.profile-meta.xml
@@ -4327,6 +4327,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Service.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Service.profile-meta.xml
@@ -4332,6 +4332,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/SolutionManager.profile-meta.xml
+++ b/unpackaged/main/default/profiles/SolutionManager.profile-meta.xml
@@ -3469,6 +3469,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Standard.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Standard.profile-meta.xml
@@ -3544,6 +3544,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Sys Admin - Limited.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Sys Admin - Limited.profile-meta.xml
@@ -6459,6 +6459,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/System Admin DevOps.profile-meta.xml
+++ b/unpackaged/main/default/profiles/System Admin DevOps.profile-meta.xml
@@ -7556,6 +7556,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>

--- a/unpackaged/main/default/profiles/Technology Partnerships.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Technology Partnerships.profile-meta.xml
@@ -3629,6 +3629,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Transformation.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Transformation.profile-meta.xml
@@ -3579,6 +3579,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/main/default/profiles/Website Services.profile-meta.xml
+++ b/unpackaged/main/default/profiles/Website Services.profile-meta.xml
@@ -3734,6 +3734,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Contract_SKU_Transaction__c.Docketwise_Stripe_Subscription_ID__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Contract_SKU_Transaction__c.Effective_Date_2__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Added Docketwise Stripe Subscription ID Field to the Contract SKU Transactions - created a permission set for visibility and edit capabilities and added that Permission set to the Senior Sales Ops Permission Set Group