### PR TITLE
Edit-Last-Assigned-Date-on-Account-Permission-set

### DIFF
--- a/unpackaged/main/default/permissionsetgroups/Senior_Sales_Ops.permissionsetgroup-meta.xml
+++ b/unpackaged/main/default/permissionsetgroups/Senior_Sales_Ops.permissionsetgroup-meta.xml
@@ -8,6 +8,7 @@
     <permissionSets>Create_Report_and_Dashboard_Folders</permissionSets>
     <permissionSets>Docketwise_Stripe_Subscsription_ID_Read_Write_Access</permissionSets>
     <permissionSets>Edit_Closed_Won_Opportunities</permissionSets>
+    <permissionSets>Edit_Last_Assigned_Date_on_Account</permissionSets>
     <permissionSets>Edit_MQL_Fields</permissionSets>
     <permissionSets>Inbound_Requests_Readonly</permissionSets>
     <permissionSets>Manage_Business_Hours_Holidays</permissionSets>

--- a/unpackaged/main/default/permissionsets/Edit_Last_Assigned_Date_on_Account.permissionset-meta.xml
+++ b/unpackaged/main/default/permissionsets/Edit_Last_Assigned_Date_on_Account.permissionset-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Allows user to edit the Last Assigned Date on Accounts</description>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Account.Last_Assigned_Date__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Edit Last Assigned Date on Account</label>
+</PermissionSet>


### PR DESCRIPTION
Added permission set Edit Last Assigned Date on account and added it to the Senior_Sales_Ops Permission Set Group