### PR TITLE
Autolaunched-Assign-MQA-Update-MQA-Disposition-Required

### DIFF
--- a/unpackaged/main/default/flows/Autolaunched_Account_Assign_MQA.flow-meta.xml
+++ b/unpackaged/main/default/flows/Autolaunched_Account_Assign_MQA.flow-meta.xml
@@ -851,6 +851,12 @@ IF(
             </value>
         </inputAssignments>
         <inputAssignments>
+            <field>MQA_Disposition_Required__c</field>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
             <field>OwnerId</field>
             <value>
                 <elementReference>Get_Assignment_Group_Member.var_AssignmentGroupMemberUserID</elementReference>
@@ -882,6 +888,12 @@ IF(
             <field>Assign_MQA__c</field>
             <value>
                 <booleanValue>false</booleanValue>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>MQA_Disposition_Required__c</field>
+            <value>
+                <booleanValue>true</booleanValue>
             </value>
         </inputAssignments>
         <inputAssignments>


### PR DESCRIPTION
Updated flow to update MQA Disposition Required to True when updating the account.